### PR TITLE
Blame index (of the input list) instead of identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Aborts are identifiable for an honest party if the following conditions hold in 
 - Nonce aggregation is performed honestly (e.g., because the honest signer performs nonce aggregation on its own or because the coordinator is trusted).
 - The partial signatures received from all signers are verified using the algorithm *PartialSigVerify*.
 
-If these conditions hold and an honest party (signer or coordinator) runs an algorithm that fails due to invalid protocol contributions from malicious signers, then the algorithm run by the honest party will output the participant identifier of exactly one malicious signer.
+If these conditions hold and an honest party (signer or coordinator) runs an algorithm that fails due to invalid protocol contributions from malicious signers, then the algorithm run by the honest party will output the index (within the input list) of exactly one malicious signer.
 Additionally, if the honest parties agree on the contributions sent by all signers in the signing session, all the honest parties who run the aborting algorithm will identify the same malicious signer.
 
 #### Further Remarks
@@ -439,15 +439,14 @@ Algorithm *NonceGen(secshare, pubshare, thresh_pk, m, extra_in)*:
 
 ### Nonce Aggregation
 
-Algorithm *NonceAgg(pubnonce<sub>1..u</sub>, id<sub>1..u</sub>)*:
+Algorithm *NonceAgg(pubnonce<sub>1..u</sub>)*:
 
 - Inputs:
   - The number *u* of signing participants: an integer with *t ≤ u ≤ n*
   - The list of participant public nonces *pubnonce<sub>1..u</sub>*: *u* 66-byte array, each an output of *NonceGen*
-  - The list of participant identifiers *id<sub>1..u</sub>*: *u* integers, each with *0 ≤ id<sub>i</sub> ≤ n-1*
 - For *j = 1 .. 2*:
   - For *i = 1 .. u*:
-    - Let *R<sub>i,j</sub> = cpoint(pubnonce<sub>i</sub>[(j-1)\*33:j\*33])*; fail if that fails and blame signer *id<sub>i</sub>* for invalid *pubnonce*
+    - Let *R<sub>i,j</sub> = cpoint(pubnonce<sub>i</sub>[(j-1)\*33:j\*33])*; fail if that fails and blame signer at index *i* for invalid *pubnonce*
   - Let *R<sub>j</sub> = R<sub>1,j</sub> + R<sub>2,j</sub> + ... + R<sub>u,j</sub>*
 - Return *aggnonce = cbytes_ext(R<sub>1</sub>) || cbytes_ext(R<sub>2</sub>)*
 
@@ -536,7 +535,7 @@ Algorithm *PartialSigVerify(psig, pubnonce<sub>1..u</sub>, signers_ctx, tweak<su
   - The index *i* of the signer in the list of public nonces where *0 < i ≤ u*
 - ValidateSignersCtx(signers_ctx); fail if that fails
 - Let *(_, _, u, id<sub>1..u</sub>, pubshare<sub>1..u</sub>, _) = signers_ctx*
-- Let *aggnonce = NonceAgg(pubnonce<sub>1..u</sub>, id<sub>1..u</sub>)*; fail if that fails
+- Let *aggnonce = NonceAgg(pubnonce<sub>1..u</sub>)*; fail if that fails
 - Let *session_ctx = (signers_ctx, aggnonce, v, tweak<sub>1..v</sub>, is_xonly_t<sub>1..v</sub>, m)*
 - Run *PartialSigVerifyInternal(psig, id<sub>i</sub>, pubnonce<sub>i</sub>, pubshare<sub>i</sub>, session_ctx)*
 - Return success iff no failure occurred before reaching this point.
@@ -561,16 +560,15 @@ Internal Algorithm *PartialSigVerifyInternal(psig, my_id, pubnonce, pubshare, se
 
 ### Partial Signature Aggregation
 
-Algorithm *PartialSigAgg(psig<sub>1..u</sub>, id<sub>1..u</sub>, session_ctx)*:
+Algorithm *PartialSigAgg(psig<sub>1..u</sub>, session_ctx)*:
 
 - Inputs:
   - The number *u* of signatures with *t ≤ u ≤ n*
   - The list of partial signatures *psig<sub>1..u</sub>*: *u* 32-byte arrays, each an output of *Sign*
-  - The list of participant identifiers *id<sub>1..u</sub>*: *u* distinct integers, each with *0 ≤ id<sub>i</sub> ≤ n-1*
   - The *session_ctx*: a [Session Context](#session-context) data structure
 - Let *(Q, _, tacc, _, _, _, R, e) = GetSessionValues(session_ctx)*; fail if that fails
 - For *i = 1 .. u*:
-  - Let *s<sub>i</sub> = scalar_from_bytes_nonzero_checked(psig<sub>i</sub>)*; fail if that fails and blame signer *id<sub>i</sub>* for invalid partial signature.
+  - Let *s<sub>i</sub> = scalar_from_bytes_nonzero_checked(psig<sub>i</sub>)*; fail if that fails and blame signer at index *i* for invalid partial signature.
 - Let *g = Scalar(1)* if *has_even_y(Q)*, otherwise let *g = Scalar(-1)*
 - Let *s = s<sub>1</sub> + ... + s<sub>u</sub> + e &middot; g &middot; tacc &ensp;(mod ord)*
 - Return *sig = xbytes(R) || scalar_to_bytes(s)*
@@ -640,11 +638,9 @@ Algorithm *DeterministicSign(secshare, my_id, aggothernonce, signers_ctx, tweak<
 - Let *my_pubshare = cbytes(d &middot; G)*
 - Fail if *my_pubshare* is not present in *pubshare<sub>1..u</sub>*
 - Let *secnonce = scalar_to_bytes(k<sub>1</sub>) || scalar_to_bytes(k<sub>2</sub>)*
-- Let *aggnonce = NonceAgg((pubnonce, aggothernonce), (my_id, COORDINATOR_ID))*[^coordinator-id-sentinel]; fail if that fails and blame coordinator for invalid *aggothernonce*.
+- Let *aggnonce = NonceAgg((pubnonce, aggothernonce))*; fail if that fails and blame coordinator for invalid *aggothernonce*.
 - Let *session_ctx = (signers_ctx, aggnonce, v, tweak<sub>1..v</sub>, is_xonly_t<sub>1..v</sub>, m)*
 - Return (pubnonce, Sign(secnonce, secshare, my_id, session_ctx))
-
-[^coordinator-id-sentinel]: *COORDINATOR_ID* is a sentinel value (not an actual participant identifier) used to track the source of *aggothernonce* for error attribution. If *NonceAgg* fails, the coordinator is blamed for providing an invalid *aggothernonce*. In the reference implementation, *COORDINATOR_ID* is represented as *None*.
 
 ### Tweaking Definition
 
@@ -786,6 +782,7 @@ This document proposes a standard for the FROST threshold signature scheme that 
 
 ## Changelog
 
+- *0.4.1* (2026-03-03): Assign blame to signer index (of the input list) instead of their identifier value
 - *0.4.0* (2026-01-30): Number 445 was assigned to this BIP.
 - *0.3.6* (2026-01-28): Add MIT license file for reference code and other auxiliary files.
 - *0.3.5* (2026-01-25): Update secp256k1lab to latest version, remove stub file, and fix formatting in the BIP text.

--- a/python/example.py
+++ b/python/example.py
@@ -160,7 +160,7 @@ async def coordinator(
         pubnonces.append(pubnonce)
 
     # Aggregate nonces
-    aggnonce = nonce_agg(pubnonces, signer_ids)
+    aggnonce = nonce_agg(pubnonces)
     chans.send_all(aggnonce)
 
     # Round 2: Collect partial signatures
@@ -174,7 +174,7 @@ async def coordinator(
         psigs.append(psig)
 
     # Aggregate partial signatures
-    final_sig = partial_sig_agg(psigs, signer_ids, session_ctx)
+    final_sig = partial_sig_agg(psigs, session_ctx)
     chans.send_all(final_sig)
 
     return final_sig

--- a/python/frost_ref/signing.py
+++ b/python/frost_ref/signing.py
@@ -8,7 +8,7 @@
 # be used in production environments. The code is vulnerable to timing attacks,
 # for example.
 
-from typing import List, Optional, Tuple, NewType, NamedTuple, Sequence, Literal
+from typing import List, Optional, Tuple, NewType, NamedTuple, Literal
 import secrets
 
 from secp256k1lab.secp256k1 import G, GE, Scalar
@@ -37,10 +37,9 @@ ContribKind = Literal[
 # values. Actual implementations should not crash when receiving invalid
 # contributions. Instead, they should hold the offending party accountable.
 class InvalidContributionError(Exception):
-    def __init__(self, signer_id: Optional[int], contrib: ContribKind) -> None:
-        # participant identifier of the signer who sent the invalid value
-        self.id = signer_id
-        # contrib is one of "pubkey", "pubnonce", "aggnonce", or "psig".
+    def __init__(self, signer_index: Optional[int], contrib: ContribKind) -> None:
+        # index of the signer who sent the invalid value, or None for coordinator
+        self.signer_index = signer_index
         self.contrib = contrib
 
 
@@ -60,11 +59,11 @@ def derive_interpolating_value(ids: List[int], my_id: int) -> Scalar:
 
 def derive_thresh_pubkey(ids: List[int], pubshares: List[PlainPk]) -> PlainPk:
     Q = GE()
-    for my_id, pubshare in zip(ids, pubshares):
+    for idx, (my_id, pubshare) in enumerate(zip(ids, pubshares)):
         try:
             X_i = GE.from_bytes_compressed(pubshare)
         except ValueError:
-            raise InvalidContributionError(my_id, "pubshare")
+            raise InvalidContributionError(idx, "pubshare")
         lam_i = derive_interpolating_value(ids, my_id)
         Q = Q + lam_i * X_i
     # Q is not the point at infinity except with negligible probability.
@@ -88,13 +87,13 @@ def validate_signers_ctx(signers_ctx: SignersContext) -> None:
         raise ValueError("The number of signers must be between t and n.")
     if len(pubshares) != len(ids):
         raise ValueError("The pubshares and ids arrays must have the same length.")
-    for i, pubshare in zip(ids, pubshares):
+    for idx, (i, pubshare) in enumerate(zip(ids, pubshares)):
         if not 0 <= i <= n - 1:
             raise ValueError(f"The participant identifier {i} is out of range.")
         try:
             _ = GE.from_bytes_compressed(pubshare)
         except ValueError:
-            raise InvalidContributionError(i, "pubshare")
+            raise InvalidContributionError(idx, "pubshare")
     if len(set(ids)) != len(ids):
         raise ValueError("The participant identifier list contains duplicate elements.")
     if derive_thresh_pubkey(ids, pubshares) != thresh_pk:
@@ -235,20 +234,15 @@ def nonce_gen(
 # in each function that takes `ids` as argument?
 
 
-# `ids` is typed as Sequence[Optional[int]] so that callers can pass either
-# List[int] or List[Optional[int]] without triggering mypy invariance errors.
-# Sequence is read-only and covariant.
-def nonce_agg(pubnonces: List[bytes], ids: Sequence[Optional[int]]) -> bytes:
-    if len(pubnonces) != len(ids):
-        raise ValueError("The pubnonces and ids arrays must have the same length.")
+def nonce_agg(pubnonces: List[bytes]) -> bytes:
     aggnonce = b""
     for j in (1, 2):
         R_j = GE()
-        for my_id, pubnonce in zip(ids, pubnonces):
+        for idx, pubnonce in enumerate(pubnonces):
             try:
                 R_ij = GE.from_bytes_compressed(pubnonce[(j - 1) * 33 : j * 33])
             except ValueError:
-                raise InvalidContributionError(my_id, "pubnonce")
+                raise InvalidContributionError(idx, "pubnonce")
             R_j = R_j + R_ij
         aggnonce += R_j.to_bytes_compressed_with_infinity()
     return aggnonce
@@ -375,9 +369,6 @@ def det_nonce_hash(
     return tagged_hash("FROST/deterministic/nonce", buf)
 
 
-COORDINATOR_ID = None
-
-
 def deterministic_sign(
     secshare: bytes,
     my_id: int,
@@ -414,11 +405,10 @@ def deterministic_sign(
     pubnonce = R1_partial.to_bytes_compressed() + R2_partial.to_bytes_compressed()
     secnonce = bytearray(k_1.to_bytes() + k_2.to_bytes())
     try:
-        aggnonce = nonce_agg([pubnonce, aggothernonce], [my_id, COORDINATOR_ID])
+        aggnonce = nonce_agg([pubnonce, aggothernonce])
     except Exception:
-        # Since `pubnonce` can never be invalid, blame coordinator's pubnonce.
-        # REVIEW: should we introduce an unknown participant or coordinator error?
-        raise InvalidContributionError(COORDINATOR_ID, "aggothernonce")
+        # pubnonce is always valid, so any failure is due to aggothernonce.
+        raise InvalidContributionError(None, "aggothernonce")
     session_ctx = SessionContext(aggnonce, signers_ctx, tweaks, is_xonly, msg)
     psig = sign(secnonce, secshare, my_id, session_ctx)
     return (pubnonce, psig)
@@ -439,7 +429,7 @@ def partial_sig_verify(
         raise ValueError("The pubnonces and ids arrays must have the same length.")
     if len(tweaks) != len(is_xonly):
         raise ValueError("The tweaks and is_xonly arrays must have the same length.")
-    aggnonce = nonce_agg(pubnonces, ids)
+    aggnonce = nonce_agg(pubnonces)
     session_ctx = SessionContext(aggnonce, signers_ctx, tweaks, is_xonly, msg)
     return partial_sig_verify_internal(
         psig, ids[i], pubnonces[i], pubshares[i], session_ctx
@@ -480,19 +470,16 @@ def partial_sig_verify_internal(
     return s * G == Re_s + (e * a * g_) * P
 
 
-def partial_sig_agg(
-    psigs: List[bytes], ids: List[int], session_ctx: SessionContext
-) -> bytes:
-    assert COORDINATOR_ID not in ids
+def partial_sig_agg(psigs: List[bytes], session_ctx: SessionContext) -> bytes:
+    (Q, _, tacc, ids, _, _, R, e) = get_session_values(session_ctx)
     if len(psigs) != len(ids):
         raise ValueError("The psigs and ids arrays must have the same length.")
-    (Q, _, tacc, _, _, _, R, e) = get_session_values(session_ctx)
     s = Scalar(0)
-    for my_id, psig in zip(ids, psigs):
+    for idx, psig in enumerate(psigs):
         try:
             s_i = Scalar.from_bytes_checked(psig)
         except ValueError:
-            raise InvalidContributionError(my_id, "psig")
+            raise InvalidContributionError(idx, "psig")
         s = s + s_i
     g = Scalar(1) if Q.has_even_y() else Scalar(-1)
     s = s + e * g * tacc

--- a/python/gen_vectors.py
+++ b/python/gen_vectors.py
@@ -301,24 +301,20 @@ def generate_nonce_agg_vectors():
     # --- Valid Test Case 1 ---
     pubnonce_indices = [0, 1]
     curr_pubnonces = [pubnonces[i] for i in pubnonce_indices]
-    pids = [0, 1]
-    aggnonce = nonce_agg(curr_pubnonces, pids)
+    aggnonce = nonce_agg(curr_pubnonces)
     vectors["valid_test_cases"].append(
         {
             "pubnonce_indices": pubnonce_indices,
-            "participant_identifiers": pids,
             "expected_aggnonce": bytes_to_hex(aggnonce),
         }
     )
     # --- Valid Test Case 2 ---
     pubnonce_indices = [2, 3]
     curr_pubnonces = [pubnonces[i] for i in pubnonce_indices]
-    pids = [0, 1]
-    aggnonce = nonce_agg(curr_pubnonces, pids)
+    aggnonce = nonce_agg(curr_pubnonces)
     vectors["valid_test_cases"].append(
         {
             "pubnonce_indices": pubnonce_indices,
-            "participant_identifiers": pids,
             "expected_aggnonce": bytes_to_hex(aggnonce),
             "comment": "Sum of second points encoded in the nonces is point at infinity which is serialized as 33 zero bytes",
         }
@@ -328,14 +324,12 @@ def generate_nonce_agg_vectors():
     # --- Error Test Case 1 ---
     pubnonce_indices = [0, INVALID_TAG_IDX]
     curr_pubnonces = [pubnonces[i] for i in pubnonce_indices]
-    pids = [0, 1]
     error = expect_exception(
-        lambda: nonce_agg(curr_pubnonces, pids), InvalidContributionError
+        lambda: nonce_agg(curr_pubnonces), InvalidContributionError
     )
     vectors["error_test_cases"].append(
         {
             "pubnonce_indices": pubnonce_indices,
-            "participant_identifiers": pids,
             "error": error,
             "comment": "Public nonce from signer 1 is invalid due wrong tag, 0x04, in the first half",
         }
@@ -343,14 +337,12 @@ def generate_nonce_agg_vectors():
     # --- Error Test Case 2 ---
     pubnonce_indices = [INVALID_XCOORD_IDX, 1]
     curr_pubnonces = [pubnonces[i] for i in pubnonce_indices]
-    pids = [0, 1]
     error = expect_exception(
-        lambda: nonce_agg(curr_pubnonces, pids), InvalidContributionError
+        lambda: nonce_agg(curr_pubnonces), InvalidContributionError
     )
     vectors["error_test_cases"].append(
         {
             "pubnonce_indices": pubnonce_indices,
-            "participant_identifiers": pids,
             "error": error,
             "comment": "Public nonce from signer 0 is invalid because the second half does not correspond to an X coordinate",
         }
@@ -358,14 +350,12 @@ def generate_nonce_agg_vectors():
     # --- Error Test Case 3 ---
     pubnonce_indices = [INVALID_EXCEEDS_FIELD_IDX, 1]
     curr_pubnonces = [pubnonces[i] for i in pubnonce_indices]
-    pids = [0, 1]
     error = expect_exception(
-        lambda: nonce_agg(curr_pubnonces, pids), InvalidContributionError
+        lambda: nonce_agg(curr_pubnonces), InvalidContributionError
     )
     vectors["error_test_cases"].append(
         {
             "pubnonce_indices": pubnonce_indices,
-            "participant_identifiers": pids,
             "error": error,
             "comment": "Public nonce from signer 0 is invalid because second half exceeds field size",
         }
@@ -409,7 +399,7 @@ def generate_sign_verify_vectors():
     ]
     vectors["secnonces_p0"] = bytes_list_to_hex(secnonces_p0)
     # compute -(pubnonce[0] + pubnonce[1])
-    tmp = nonce_agg(pubnonces[:2], ids[:2])
+    tmp = nonce_agg(pubnonces[:2])
     R1 = GE.from_bytes_compressed_with_infinity(tmp[0:33])
     R2 = GE.from_bytes_compressed_with_infinity(tmp[33:66])
     neg_R1 = -R1
@@ -431,10 +421,7 @@ def generate_sign_verify_vectors():
     # 5 -> invalid x coordinate in second half
     # 6 -> second half exceeds field size
     indices_grp = [[0, 1], [0, 2], [0, 1, 2]]
-    aggnonces = [
-        nonce_agg([pubnonces[i] for i in indices], [ids[i] for i in indices])
-        for indices in indices_grp
-    ]
+    aggnonces = [nonce_agg([pubnonces[i] for i in indices]) for indices in indices_grp]
     # aggnonce with inf points
     aggnonces.append(
         nonce_agg(
@@ -443,7 +430,6 @@ def generate_sign_verify_vectors():
                 pubnonces[1],
                 pubnonces[-1],
             ],  # pubnonces[-1] is inv_pubnonce
-            [ids[0], ids[1], ids[2]],
         )
     )
     # invalid aggnonces
@@ -846,15 +832,11 @@ def generate_tweak_vectors():
 
     # create valid aggnonces
     indices_grp = [[0, 1], [0, 1, 2]]
-    aggnonces = [
-        nonce_agg([pubnonces[i] for i in indices], [ids[i] for i in indices])
-        for indices in indices_grp
-    ]
+    aggnonces = [nonce_agg([pubnonces[i] for i in indices]) for indices in indices_grp]
     # aggnonce with inf points
     aggnonces.append(
         nonce_agg(
             [pubnonces[0], pubnonces[1], pubnonces[-1]],
-            [ids[0], ids[1], ids[2]],
         )
     )
     vectors["aggnonces"] = bytes_list_to_hex(aggnonces)
@@ -1090,7 +1072,6 @@ def generate_det_sign_vectors():
         curr_tweak_modes = case.get("is_xonly", [])
 
         # generate `aggothernonce`
-        other_ids = curr_ids[:signer_index] + curr_ids[signer_index + 1 :]
         other_pubnonces = []
         for i in case["indices"]:
             if i == signer_index:
@@ -1100,7 +1081,7 @@ def generate_det_sign_vectors():
                 tmp, secshares[i], pubshares[i], xonly_thresh_pk, curr_msg, None
             )
             other_pubnonces.append(pub)
-        curr_aggothernonce = nonce_agg(other_pubnonces, other_ids)
+        curr_aggothernonce = nonce_agg(other_pubnonces)
 
         curr_signers = SignersContext(n, t, curr_ids, curr_pubshares, thresh_pk)
         expected = deterministic_sign(
@@ -1229,10 +1210,6 @@ def generate_det_sign_vectors():
         # generate `aggothernonce`
         is_aggothernonce = case.get("aggothernonce", None)
         if is_aggothernonce is None:
-            if signer_index is None:
-                other_ids = curr_ids[1:]
-            else:
-                other_ids = curr_ids[:signer_index] + curr_ids[signer_index + 1 :]
             other_pubnonces = []
             for i in case["ids"]:
                 if i == signer_index:
@@ -1242,7 +1219,7 @@ def generate_det_sign_vectors():
                     tmp, secshares[i], pubshares[i], xonly_thresh_pk, curr_msg, None
                 )
                 other_pubnonces.append(pub)
-            curr_aggothernonce = nonce_agg(other_pubnonces, other_ids)
+            curr_aggothernonce = nonce_agg(other_pubnonces)
         else:
             curr_aggothernonce = bytes.fromhex(is_aggothernonce)
 
@@ -1336,7 +1313,7 @@ def generate_sig_agg_vectors():
         curr_ids = [ids[i] for i in case["indices"]]
         curr_pubshares = [pubshares[i] for i in case["indices"]]
         curr_pubnonces = [pubnonces[i] for i in case["indices"]]
-        curr_aggnonce = nonce_agg(curr_pubnonces, curr_ids)
+        curr_aggnonce = nonce_agg(curr_pubnonces)
         curr_msg = msg
         tweak_indices = case.get("tweaks", [])
         curr_tweaks = [SIG_AGG_TWEAKS[i] for i in tweak_indices]
@@ -1355,7 +1332,7 @@ def generate_sig_agg_vectors():
             sig = sign(bytearray(secnonces[i]), secshares[i], my_id, session_ctx)
             psigs.append(sig)
             # TODO: verify the signatures here
-        bip340_sig = partial_sig_agg(psigs, curr_ids, session_ctx)
+        bip340_sig = partial_sig_agg(psigs, session_ctx)
         vectors["valid_test_cases"].append(
             {
                 "id_indices": case["indices"],
@@ -1388,7 +1365,7 @@ def generate_sig_agg_vectors():
         curr_ids = [ids[i] for i in case["indices"]]
         curr_pubshares = [pubshares[i] for i in case["indices"]]
         curr_pubnonces = [pubnonces[i] for i in case["indices"]]
-        curr_aggnonce = nonce_agg(curr_pubnonces, curr_ids)
+        curr_aggnonce = nonce_agg(curr_pubnonces)
         curr_msg = msg
         psigs = []
         curr_signers = SignersContext(n, t, curr_ids, curr_pubshares, thresh_pk)
@@ -1411,7 +1388,7 @@ def generate_sig_agg_vectors():
             ValueError if case["error"] == "value" else InvalidContributionError
         )
         error = expect_exception(
-            lambda: partial_sig_agg(psigs, curr_ids, session_ctx), expected_exception
+            lambda: partial_sig_agg(psigs, session_ctx), expected_exception
         )
         vectors["error_test_cases"].append(
             {

--- a/python/tests.py
+++ b/python/tests.py
@@ -8,7 +8,6 @@ import time
 from typing import List, Optional, Tuple
 
 from frost_ref.signing import (
-    COORDINATOR_ID,
     InvalidContributionError,
     PlainPk,
     SessionContext,
@@ -60,11 +59,14 @@ def get_error_details(test_case):
         if "contrib" in error:
 
             def except_fn(e):
-                return e.id == error["id"] and e.contrib == error["contrib"]
+                return (
+                    e.signer_index == error["signer_index"]
+                    and e.contrib == error["contrib"]
+                )
         else:
 
             def except_fn(e):
-                return e.id == error["id"]
+                return e.signer_index == error["signer_index"]
     elif error["type"] == "ValueError":
         exception = ValueError
 
@@ -134,18 +136,14 @@ def test_nonce_agg_vectors():
     error_test_cases = test_data["error_test_cases"]
 
     for test_case in valid_test_cases:
-        # todo: assert the t <= len(pubnonces, ids) <= n
-        # todo: assert the values of ids too? 1 <= id <= n?
         pubnonces = [pubnonces_list[i] for i in test_case["pubnonce_indices"]]
-        ids = test_case["participant_identifiers"]
         expected_aggnonce = bytes.fromhex(test_case["expected_aggnonce"])
-        assert nonce_agg(pubnonces, ids) == expected_aggnonce
+        assert nonce_agg(pubnonces) == expected_aggnonce
 
     for test_case in error_test_cases:
         exception, except_fn = get_error_details(test_case)
         pubnonces = [pubnonces_list[i] for i in test_case["pubnonce_indices"]]
-        ids = test_case["participant_identifiers"]
-        assert_raises(exception, lambda: nonce_agg(pubnonces, ids), except_fn)
+        assert_raises(exception, lambda: nonce_agg(pubnonces), except_fn)
 
 
 # todo: include vectors from the frost draft too
@@ -187,7 +185,7 @@ def test_sign_verify_vectors():
         pubnonces_tmp = [pubnonces[i] for i in test_case["pubnonce_indices"]]
         aggnonce_tmp = aggnonces[test_case["aggnonce_index"]]
         # Make sure that pubnonces and aggnonce in the test vector are consistent
-        assert nonce_agg(pubnonces_tmp, ids_tmp) == aggnonce_tmp
+        assert nonce_agg(pubnonces_tmp) == aggnonce_tmp
         msg = msgs[test_case["msg_index"]]
         signer_index = test_case["signer_index"]
         my_id = ids_tmp[signer_index]
@@ -299,7 +297,7 @@ def test_tweak_vectors():
         pubnonces_tmp = [pubnonces[i] for i in test_case["pubnonce_indices"]]
         aggnonce_tmp = aggnonces[test_case["aggnonce_index"]]
         # Make sure that pubnonces and aggnonce in the test vector are consistent
-        assert nonce_agg(pubnonces_tmp, ids_tmp) == aggnonce_tmp
+        assert nonce_agg(pubnonces_tmp) == aggnonce_tmp
         tweaks_tmp = [tweaks[i] for i in test_case["tweak_indices"]]
         tweak_modes_tmp = test_case["is_xonly"]
         signer_index = test_case["signer_index"]
@@ -393,7 +391,7 @@ def test_det_sign_vectors():
         assert psig == expected[1]
 
         pubnonces = [aggothernonce, pubnonce]
-        aggnonce_tmp = nonce_agg(pubnonces, [COORDINATOR_ID, my_id])
+        aggnonce_tmp = nonce_agg(pubnonces)
         session_ctx = SessionContext(aggnonce_tmp, signers_tmp, tweaks, is_xonly, msg)
         assert partial_sig_verify_internal(
             psig, my_id, pubnonce, pubshares_tmp[signer_index], session_ctx
@@ -457,7 +455,7 @@ def test_sig_agg_vectors():
         pubnonces_tmp = [pubnonces[i] for i in test_case["pubnonce_indices"]]
         aggnonce_tmp = bytes.fromhex(test_case["aggnonce"])
         # Make sure that pubnonces and aggnonce in the test vector are consistent
-        assert aggnonce_tmp == nonce_agg(pubnonces_tmp, ids_tmp)
+        assert aggnonce_tmp == nonce_agg(pubnonces_tmp)
 
         tweaks_tmp = [tweaks[i] for i in test_case["tweak_indices"]]
         tweak_modes_tmp = test_case["is_xonly"]
@@ -480,7 +478,7 @@ def test_sig_agg_vectors():
                 i,
             )
 
-        bip340sig = partial_sig_agg(psigs_tmp, ids_tmp, session_ctx)
+        bip340sig = partial_sig_agg(psigs_tmp, session_ctx)
         assert bip340sig == expected
         tweaked_thresh_pk = get_xonly_pk(
             thresh_pubkey_and_tweak(thresh_pk, tweaks_tmp, tweak_modes_tmp)
@@ -505,7 +503,7 @@ def test_sig_agg_vectors():
         )
         assert_raises(
             exception,
-            lambda: partial_sig_agg(psigs_tmp, ids_tmp, session_ctx),
+            lambda: partial_sig_agg(psigs_tmp, session_ctx),
             except_fn,
         )
 
@@ -580,7 +578,7 @@ def test_sign_and_verify_random(iterations: int) -> None:
             )
             signer_secnonces.append(secnonce_final)
         else:
-            aggothernonce = nonce_agg(signer_pubnonces, signer_ids[:-1])
+            aggothernonce = nonce_agg(signer_pubnonces)
             rand = secrets.token_bytes(32)
             pubnonce_final, psig_final = deterministic_sign(
                 signer_secshares[-1],
@@ -594,7 +592,7 @@ def test_sign_and_verify_random(iterations: int) -> None:
             )
 
         signer_pubnonces.append(pubnonce_final)
-        aggnonce = nonce_agg(signer_pubnonces, signer_ids)
+        aggnonce = nonce_agg(signer_pubnonces)
         session_ctx = SessionContext(aggnonce, signers_ctx, tweaks, tweak_modes, msg)
 
         signer_psigs = []
@@ -646,7 +644,7 @@ def test_sign_and_verify_random(iterations: int) -> None:
             0,
         )
 
-        bip340sig = partial_sig_agg(signer_psigs, signer_ids, session_ctx)
+        bip340sig = partial_sig_agg(signer_psigs, session_ctx)
         assert schnorr_verify(msg, tweaked_thresh_pk, bip340sig)
 
 

--- a/python/vectors/det_sign_vectors.json
+++ b/python/vectors/det_sign_vectors.json
@@ -322,7 +322,7 @@
             "signer_index": 0,
             "error": {
                 "type": "InvalidContributionError",
-                "id": 1,
+                "signer_index": 1,
                 "contrib": "pubshare"
             },
             "comment": "Signer 1 provided an invalid participant public share"
@@ -344,7 +344,7 @@
             "signer_index": 0,
             "error": {
                 "type": "InvalidContributionError",
-                "id": null,
+                "signer_index": null,
                 "contrib": "aggothernonce"
             },
             "comment": "aggothernonce is invalid due wrong tag, 0x04, in the first half"
@@ -366,7 +366,7 @@
             "signer_index": 0,
             "error": {
                 "type": "InvalidContributionError",
-                "id": null,
+                "signer_index": null,
                 "contrib": "aggothernonce"
             },
             "comment": "aggothernonce is invalid because first half corresponds to point at infinity"

--- a/python/vectors/nonce_agg_vectors.json
+++ b/python/vectors/nonce_agg_vectors.json
@@ -14,20 +14,12 @@
                 0,
                 1
             ],
-            "participant_identifiers": [
-                0,
-                1
-            ],
             "expected_aggnonce": "035FE1873B4F2967F52FEA4A06AD5A8ECCBE9D0FD73068012C894E2E87CCB5804B024725377345BDE0E9C33AF3C43C0A29A9249F2F2956FA8CFEB55C8573D0262DC8"
         },
         {
             "pubnonce_indices": [
                 2,
                 3
-            ],
-            "participant_identifiers": [
-                0,
-                1
             ],
             "expected_aggnonce": "035FE1873B4F2967F52FEA4A06AD5A8ECCBE9D0FD73068012C894E2E87CCB5804B000000000000000000000000000000000000000000000000000000000000000000",
             "comment": "Sum of second points encoded in the nonces is point at infinity which is serialized as 33 zero bytes"
@@ -39,13 +31,9 @@
                 0,
                 4
             ],
-            "participant_identifiers": [
-                0,
-                1
-            ],
             "error": {
                 "type": "InvalidContributionError",
-                "id": 1,
+                "signer_index": 1,
                 "contrib": "pubnonce"
             },
             "comment": "Public nonce from signer 1 is invalid due wrong tag, 0x04, in the first half"
@@ -55,13 +43,9 @@
                 5,
                 1
             ],
-            "participant_identifiers": [
-                0,
-                1
-            ],
             "error": {
                 "type": "InvalidContributionError",
-                "id": 0,
+                "signer_index": 0,
                 "contrib": "pubnonce"
             },
             "comment": "Public nonce from signer 0 is invalid because the second half does not correspond to an X coordinate"
@@ -71,13 +55,9 @@
                 6,
                 1
             ],
-            "participant_identifiers": [
-                0,
-                1
-            ],
             "error": {
                 "type": "InvalidContributionError",
-                "id": 0,
+                "signer_index": 0,
                 "contrib": "pubnonce"
             },
             "comment": "Public nonce from signer 0 is invalid because second half exceeds field size"

--- a/python/vectors/sig_agg_vectors.json
+++ b/python/vectors/sig_agg_vectors.json
@@ -152,7 +152,7 @@
             ],
             "error": {
                 "type": "InvalidContributionError",
-                "id": 1,
+                "signer_index": 1,
                 "contrib": "psig"
             },
             "comment": "Partial signature is invalid because it exceeds group size"

--- a/python/vectors/sign_verify_vectors.json
+++ b/python/vectors/sign_verify_vectors.json
@@ -276,7 +276,7 @@
             "secnonce_index": 0,
             "error": {
                 "type": "InvalidContributionError",
-                "id": 1,
+                "signer_index": 1,
                 "contrib": "pubshare"
             },
             "comment": "Signer 1 provided an invalid participant public share"
@@ -296,7 +296,7 @@
             "secnonce_index": 0,
             "error": {
                 "type": "InvalidContributionError",
-                "id": null,
+                "signer_index": null,
                 "contrib": "aggnonce"
             },
             "comment": "Aggregate nonce is invalid due wrong tag, 0x04, in the first half"
@@ -316,7 +316,7 @@
             "secnonce_index": 0,
             "error": {
                 "type": "InvalidContributionError",
-                "id": null,
+                "signer_index": null,
                 "contrib": "aggnonce"
             },
             "comment": "Aggregate nonce is invalid because the second half does not correspond to an X coordinate"
@@ -336,7 +336,7 @@
             "secnonce_index": 0,
             "error": {
                 "type": "InvalidContributionError",
-                "id": null,
+                "signer_index": null,
                 "contrib": "aggnonce"
             },
             "comment": "Aggregate nonce is invalid because second half exceeds field size"
@@ -436,7 +436,7 @@
             "signer_index": 0,
             "error": {
                 "type": "InvalidContributionError",
-                "id": 0,
+                "signer_index": 0,
                 "contrib": "pubnonce"
             },
             "comment": "Invalid pubnonce"
@@ -459,7 +459,7 @@
             "signer_index": 0,
             "error": {
                 "type": "InvalidContributionError",
-                "id": 0,
+                "signer_index": 0,
                 "contrib": "pubshare"
             },
             "comment": "Invalid pubshare"


### PR DESCRIPTION
When `InvalidContributionError` is raised, the caller needs to know who misbehaved so they can inspect the related inputs. Previously, the error reported the participant identifier. To use that, the caller had to search through the `ids` list to find the matching position before they could look up the corresponding pubnonce, psig, or pubshare. Reporting the list index directly removes that extra step, the caller can immediately access the relevant entry in every parallel input list.

Switching to index-based blame also simplifies the API. `nonce_agg` and `partial_sig_agg` previously required an `ids` parameter whose only purpose was blame attribution, the computation inside those functions does not use it. With index-based blame, that parameter is no longer needed, and both functions now assign blame by enumerating over their input lists. BIP327 (MuSig2) uses the same approach in its reference implementation.