### PR TITLE
bip, python: pass deserialized pubshares to derive_thresh_pubkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,21 +310,20 @@ Algorithm *ValidateSignersCtx(signers_ctx)*:
 - Fail if not *t ≤ u ≤ n*
 - For *i = 1 .. u*:
   - Fail if not *0 ≤ id<sub>i</sub> ≤ n - 1*
-  - Fail if *cpoint(pubshare<sub>i</sub>)* fails; blame signer at index *i* for invalid *pubshare*
+  - Let *P<sub>i</sub> = cpoint(pubshare<sub>i</sub>)*; fail if that fails
 - Fail if *has_duplicates(id<sub>1..u</sub>)*
-- Fail if *DeriveThreshPubkey(id<sub>1..u</sub>, pubshare<sub>1..u</sub>) ≠ thresh_pk*
+- Fail if *DeriveThreshPubkey(id<sub>1..u</sub>, P<sub>1..u</sub>) ≠ thresh_pk*
 - No return
 
-Internal Algorithm *DeriveThreshPubkey(id<sub>1..u</sub>,  pubshare<sub>1..u</sub>)*[^derive-thresh-no-validate-inputs]
+Internal Algorithm *DeriveThreshPubkey(id<sub>1..u</sub>, P<sub>1..u</sub>)*[^derive-thresh-no-validate-inputs]
 
 - *Q = inf_point*
 - For *i = 1..u*:
-  - *P* = cpoint(pubshare<sub>i</sub>); fail if that fails
   - *&lambda; = DeriveInterpolatingValue(id<sub>1..u</sub>, id<sub>i</sub>)*
-  - *Q = Q + &lambda; &middot; P*
+  - *Q = Q + &lambda; &middot; P<sub>i</sub>*
 - Return *cbytes(Q)*
 
-[^derive-thresh-no-validate-inputs]: *DeriveThreshPubkey* does not check that its inputs are in range. This validation is performed by *ValidateSignersCtx*, which is its only caller.
+[^derive-thresh-no-validate-inputs]: *DeriveThreshPubkey* does not validate its inputs. Its only caller, *ValidateSignersCtx*, deserializes the public shares into points and validates them (and the identifiers) beforehand.
 
 Internal Algorithm *DeriveInterpolatingValue(id<sub>1..u</sub>, my_id):*
 

--- a/python/frost_ref/signing.py
+++ b/python/frost_ref/signing.py
@@ -57,13 +57,10 @@ def derive_interpolating_value(ids: List[int], my_id: int) -> Scalar:
     return num / deno
 
 
-def derive_thresh_pubkey(ids: List[int], pubshares: List[PlainPk]) -> PlainPk:
+def derive_thresh_pubkey(ids: List[int], pubshares: List[GE]) -> PlainPk:
+    assert len(ids) == len(pubshares)
     Q = GE()
-    for idx, (my_id, pubshare) in enumerate(zip(ids, pubshares)):
-        try:
-            X_i = GE.from_bytes_compressed(pubshare)
-        except ValueError:
-            raise InvalidContributionError(idx, "pubshare")
+    for my_id, X_i in zip(ids, pubshares):
         lam_i = derive_interpolating_value(ids, my_id)
         Q = Q + lam_i * X_i
     # Q is not the point at infinity except with negligible probability.
@@ -87,18 +84,20 @@ def validate_signers_ctx(signers_ctx: SignersContext) -> None:
         raise ValueError("The number of signers must be between t and n.")
     if len(pubshares) != len(ids):
         raise ValueError("The pubshares and ids arrays must have the same length.")
+    pubshare_points = []
     for idx, (i, pubshare) in enumerate(zip(ids, pubshares)):
         if not 0 <= i <= n - 1:
             raise ValueError(
                 f"The participant identifier at index {idx} is out of range."
             )
         try:
-            _ = GE.from_bytes_compressed(pubshare)
+            P = GE.from_bytes_compressed(pubshare)
         except ValueError:
             raise ValueError(f"Invalid pubshare at index {idx}.")
+        pubshare_points.append(P)
     if len(set(ids)) != len(ids):
         raise ValueError("The participant identifier list contains duplicate elements.")
-    if derive_thresh_pubkey(ids, pubshares) != thresh_pk:
+    if derive_thresh_pubkey(ids, pubshare_points) != thresh_pk:
         raise ValueError("The provided key material is incorrect.")
 
 


### PR DESCRIPTION
`validate_signers_ctx` already deserializes each pubshare to check its format, so hand those points straight to `derive_thresh_pubkey` instead of decoding them a second time. drops the duplicate `cpoint` call and the redundant `InvalidContributionError` raise inside `derive_thresh_pubkey`, and updates the spec to match (DeriveThreshPubkey now takes points, and its body no longer contradicts the footnote).