### PR TITLE
Multi-(t, n) config support for test vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,6 +804,7 @@ This document proposes a standard for the FROST threshold signature scheme that 
 
 ## Changelog
 
+- *0.6.0* (2026-06-09): Expand test vectors to cover multiple (t, n) configurations (1-of-3, 2-of-3, 3-of-3, and 3-of-5) instead of the single 2-of-3 setup.
 - *0.5.2* (2026-06-03): Make *aggothernonce* an optional argument in *DeterministicSign*, allowing a sole signer in a *1-of-n* setup to sign without aggregating other signers' nonces.
 - *0.5.1* (2026-06-02): Add a footnote explaining why the signer identifiers are sorted when deriving the nonce coefficient *b*, which prevents a secret share recovery attack in *DeterministicSign*.
 - *0.5.0* (2026-05-21): Introduces the following changes:

--- a/python/frost_ref/signing.py
+++ b/python/frost_ref/signing.py
@@ -16,7 +16,7 @@ from secp256k1lab.util import tagged_hash, xor_bytes
 
 PlainPk = NewType("PlainPk", bytes)
 XonlyPk = NewType("XonlyPk", bytes)
-ContribKind = Literal["aggothernonce", "aggnonce", "psig", "pubnonce", "pubshare"]
+ContribKind = Literal["aggothernonce", "aggnonce", "psig", "pubnonce"]
 
 # Tagged hash domain-separation tags. The challenge tag is inherited from
 # BIP340 for signature compatibility; the rest are specific to this BIP.
@@ -49,10 +49,14 @@ class InvalidContributionError(Exception):
         self.contrib = contrib
 
 
+def has_duplicates(lst: List[int]) -> bool:
+    return len(set(lst)) != len(lst)
+
+
 def derive_interpolating_value(ids: List[int], my_id: int) -> Scalar:
     assert my_id in ids
     assert 0 <= my_id < 2**32
-    assert len(set(ids)) == len(ids)
+    assert not has_duplicates(ids)
     num = Scalar(1)
     deno = Scalar(1)
     for curr_id in ids:
@@ -99,9 +103,13 @@ def validate_signers_ctx(signers_ctx: SignersContext) -> None:
         try:
             P = GE.from_bytes_compressed(pubshare)
         except ValueError:
+            # A malformed pubshare is invalid pre-protocol input, not a protocol
+            # contribution: the signers context is agreed upon before signing
+            # begins, so we signal it with ValueError rather than blaming a
+            # signer via InvalidContributionError.
             raise ValueError(f"Invalid pubshare at index {idx}.")
         pubshare_points.append(P)
-    if len(set(ids)) != len(ids):
+    if has_duplicates(ids):
         raise ValueError("The participant identifier list contains duplicate elements.")
     if derive_thresh_pubkey(ids, pubshare_points) != thresh_pk:
         raise ValueError("The provided key material is incorrect.")

--- a/python/generators/common.py
+++ b/python/generators/common.py
@@ -2,10 +2,17 @@ import json
 import os
 import re
 import secrets
+from collections import namedtuple
 from typing import Dict, List, Sequence, Union
 
-from frost_ref.signing import derive_interpolating_value, nonce_gen_internal
-from secp256k1lab.secp256k1 import Scalar
+from frost_ref.signing import (
+    PlainPk,
+    XonlyPk,
+    derive_interpolating_value,
+    nonce_agg,
+    nonce_gen_internal,
+)
+from secp256k1lab.secp256k1 import GE, Scalar
 from secp256k1lab.keys import pubkey_gen_plain
 from trusted_dealer import trusted_dealer_keygen
 
@@ -87,6 +94,12 @@ INVALID_PUBSHARE = bytes.fromhex(
     "020000000000000000000000000000000000000000000000000000000000000007"
 )
 
+# Public nonce whose first half is an off-curve compressed point (x=9 not on the
+# curve) and whose second half is a valid point
+INVALID_PUBNONCE = bytes.fromhex(
+    "0200000000000000000000000000000000000000000000000000000000000000090287BF891D2A6DEAEBADC909352AA9405D1428C15F4B75F04DAE642A95C2548480"
+)
+
 
 _SCALAR_TOKEN = r"-?\d+|true|false|null"
 _SCALAR_ARRAY_RE = re.compile(
@@ -139,7 +152,7 @@ SECKEY_3OF3 = bytes.fromhex(
     "70E90852E9541FE47552B738A14C2B9B5B38C0979D640BA8C7A5A5EEE1BDA405"
 )
 SECKEY_3OF5 = bytes.fromhex(
-    "827FBF411520966DAF1D5D8BDAFCA4FEC34EEB7A954927D8AA1FD55BDDD15902"
+    "C97F278DAC5FC3214F4C2DD7551C84D4854DCA143887F54692735C61A16E902A"
 )
 
 
@@ -152,3 +165,117 @@ def frost_keygen(seckey=None, n=3, t=2):
     thresh_pk, secshares, pubshares = trusted_dealer_keygen(seckey, n, t)
     assert thresh_pk == pubkey_gen_plain(seckey)
     return (n, t, thresh_pk, list(range(n)), secshares, pubshares)
+
+
+# --- Multi-(t, n) config machinery (shared by all four signing generators) ---
+
+Config = namedtuple("Config", ["tg_id", "t", "n", "seckey"])
+
+CONFIGS = [
+    Config("2of3", 2, 3, SECKEY_2OF3),
+    Config("1of3", 1, 3, SECKEY_1OF3),
+    Config("3of3", 3, 3, SECKEY_3OF3),
+    Config("3of5", 3, 5, SECKEY_3OF5),
+]
+
+
+class SharedGroupInputs:
+    """The maximal per-test-group bundle: real key/nonce material plus the union pools
+    (real entries followed by appended fault slots) and the named offsets that index
+    those slots. Built once per test group; each generator slices what it needs."""
+
+    def __init__(self, cfg):
+        n, t, thresh_pk, _ids, secshares, pubshares = frost_keygen(
+            cfg.seckey, cfg.n, cfg.t
+        )
+        self.n = n
+        self.t = t
+        self.thresh_pk = thresh_pk
+        self.xonly_thresh_pk = XonlyPk(thresh_pk[1:])
+        self.secshares = secshares
+        self.pubshares = pubshares
+        self.secnonces, self.pubnonces = generate_all_nonces(
+            COMMON_RAND, secshares, pubshares, self.xonly_thresh_pk
+        )
+
+        # pubshares pool: off-curve point at slot n.
+        self.pool_pubshares = pubshares + [PlainPk(INVALID_PUBSHARE)]
+        # secshares pool: zero scalar at slot n.
+        self.pool_secshares = secshares + [b"\x00" * 32]
+
+        # pubnonces pool: off-curve nonce at slot n, then the inverse nonce at slot
+        # n+1 (negation of the aggregate of the first n-1 real pubnonces)
+        tmp = nonce_agg(self.pubnonces[: n - 1])
+        R1 = GE.from_bytes_compressed_with_infinity(tmp[0:33])
+        R2 = GE.from_bytes_compressed_with_infinity(tmp[33:66])
+        inverse_pubnonce = (-R1).to_bytes_compressed_with_infinity() + (
+            -R2
+        ).to_bytes_compressed_with_infinity()
+        self.pool_pubnonces = self.pubnonces + [INVALID_PUBNONCE, inverse_pubnonce]
+
+        # secnonces pool: all-zero at slot n, nonzero-first/zero-second at slot n+1.
+        zero_second_secnonce = self.secnonces[0][0:32] + b"\x00" * 32
+        assert Scalar.from_bytes_nonzero_checked(zero_second_secnonce[0:32])
+        self.pool_secnonces = self.secnonces + [b"\x00" * 64, zero_second_secnonce]
+
+        # tweaks pool: 4 common tweaks, out-of-range tweak, then the per-config
+        # infinity tweak (negation of the reconstructed threshold secret over the
+        # minimum set; degenerates to -secshares[0] at t=1).
+        infinity_tweak = (
+            -reconstruct_thresh_sk(list(range(t)), secshares[:t])
+        ).to_bytes()
+        self.tweaks_pool = list(COMMON_TWEAKS) + [OUT_OF_RANGE_TWEAK, infinity_tweak]
+
+        # named offsets into the pools, all derived from n
+        self.INVALID_PUBSHARE_IDX = n
+        self.SECSHARE_ZERO_IDX = n
+        self.INVALID_PUBNONCE_IDX = n
+        self.INVERSE_PUBNONCE_IDX = n + 1
+        self.SECNONCE_ZERO_IDX = n
+        self.SECNONCE_ZERO_SECOND_IDX = n + 1
+        self.OUT_OF_RANGE_ID = n
+        # tweaks-pool offsets, n-independent
+        self.OUT_OF_RANGE_TWEAK_IDX = 4
+        self.INFINITY_TWEAK_IDX = 5
+
+
+def get_subset(cfg, strategy="min"):
+    match strategy:
+        case "min":  # minimum threshold subset, the first t ids
+            return list(range(cfg.t))
+        case "full":  # all n participants
+            return list(range(cfg.n))
+        case "alt":  # id 0 + the last t-1 ids; collapses to [0] at t=1 (caller guards)
+            return [0] + list(range(cfg.n - cfg.t + 1, cfg.n))
+        case "min2":  # size-at-least-2 baseline; [0, 1] at t=1
+            return list(range(max(cfg.t, 2)))
+        case "wrong":  # t ids from 1, excludes id 0 (caller guards t>=2 and t<n)
+            return list(range(1, cfg.t + 1))
+        case _:
+            raise ValueError(f"Unknown subset strategy: {strategy}")
+
+
+def swap_last_two(indices):
+    result = list(indices)
+    if len(result) >= 2:
+        result[-1], result[-2] = result[-2], result[-1]
+    return result
+
+
+def set_group_config(group, cfg, inputs):
+    thresh_pk = pubkey_gen_plain(cfg.seckey)
+    assert thresh_pk == inputs.thresh_pk
+    group["tg_id"] = cfg.tg_id
+    group["t"] = cfg.t
+    group["n"] = cfg.n
+    group["thresh_pk"] = bytes_to_hex(thresh_pk)
+
+
+def assign_tc_ids(groups):
+    tc_id = 1
+    for group in groups:
+        for key, value in group.items():
+            if isinstance(value, list) and value and isinstance(value[0], dict):
+                for i, case in enumerate(value):
+                    group[key][i] = {"tc_id": tc_id, **case}
+                    tc_id += 1

--- a/python/generators/common.py
+++ b/python/generators/common.py
@@ -12,7 +12,7 @@ from frost_ref.signing import (
     nonce_agg,
     nonce_gen_internal,
 )
-from secp256k1lab.secp256k1 import GE, Scalar
+from secp256k1lab.secp256k1 import G, GE, Scalar
 from secp256k1lab.keys import pubkey_gen_plain
 from trusted_dealer import trusted_dealer_keygen
 
@@ -86,10 +86,10 @@ COMMON_TWEAKS = hex_list_to_bytes(
     ]
 )
 
-OUT_OF_RANGE_TWEAK = bytes.fromhex(
-    "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
-)
-
+# secp256k1 group order n: the single out-of-range boundary shared by the tweak and
+# partial-signature generators
+GROUP_ORDER = GE.ORDER.to_bytes(32, "big")
+OUT_OF_RANGE_TWEAK = GROUP_ORDER
 INVALID_PUBSHARE = bytes.fromhex(
     "020000000000000000000000000000000000000000000000000000000000000007"
 )
@@ -98,6 +98,10 @@ INVALID_PUBSHARE = bytes.fromhex(
 # curve) and whose second half is a valid point
 INVALID_PUBNONCE = bytes.fromhex(
     "0200000000000000000000000000000000000000000000000000000000000000090287BF891D2A6DEAEBADC909352AA9405D1428C15F4B75F04DAE642A95C2548480"
+)
+
+AGGNONCE_WRONG_TAG = bytes.fromhex(
+    "048465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61037496A3CC86926D452CAFCFD55D25972CA1675D549310DE296BFF42F72EEEA8C9"
 )
 
 
@@ -142,15 +146,19 @@ def reconstruct_thresh_sk(ids, secshares):
     return result
 
 
+# Chosen so the threshold pubkey is odd-y (prefix 03)
 SECKEY_1OF3 = bytes.fromhex(
     "06D47E05E97481428654563E5AE69C20C49642773B7334220E63110259A30C32"
 )
+# Chosen so the threshold pubkey is even-y (prefix 02)
 SECKEY_2OF3 = bytes.fromhex(
     "4C08C37F5B9A88FAE396A06E286BA41B654457BF5E35B4A693096ED9AB1491F5"
 )
+# Chosen so the threshold pubkey is even-y (prefix 02)
 SECKEY_3OF3 = bytes.fromhex(
     "70E90852E9541FE47552B738A14C2B9B5B38C0979D640BA8C7A5A5EEE1BDA405"
 )
+# Chosen so the threshold pubkey is odd-y (prefix 03)
 SECKEY_3OF5 = bytes.fromhex(
     "C97F278DAC5FC3214F4C2DD7551C84D4854DCA143887F54692735C61A16E902A"
 )
@@ -204,7 +212,9 @@ class SharedGroupInputs:
         self.pool_secshares = secshares + [b"\x00" * 32]
 
         # pubnonces pool: off-curve nonce at slot n, then the inverse nonce at slot
-        # n+1 (negation of the aggregate of the first n-1 real pubnonces)
+        # n+1 (negation of the aggregate of the first n-1 real pubnonces). It only
+        # sums to infinity when paired with indices [0..n-2] plus INVERSE_PUBNONCE_IDX.
+        # Any other size n-1 subset yields a non-infinity aggregate.
         tmp = nonce_agg(self.pubnonces[: n - 1])
         R1 = GE.from_bytes_compressed_with_infinity(tmp[0:33])
         R2 = GE.from_bytes_compressed_with_infinity(tmp[33:66])
@@ -221,9 +231,11 @@ class SharedGroupInputs:
         # tweaks pool: 4 common tweaks, out-of-range tweak, then the per-config
         # infinity tweak (negation of the reconstructed threshold secret over the
         # minimum set; degenerates to -secshares[0] at t=1).
-        infinity_tweak = (
-            -reconstruct_thresh_sk(list(range(t)), secshares[:t])
-        ).to_bytes()
+        infinity_tweak_scalar = -reconstruct_thresh_sk(list(range(t)), secshares[:t])
+        assert (
+            GE.from_bytes_compressed(self.thresh_pk) + infinity_tweak_scalar * G
+        ).infinity
+        infinity_tweak = infinity_tweak_scalar.to_bytes()
         self.tweaks_pool = list(COMMON_TWEAKS) + [OUT_OF_RANGE_TWEAK, infinity_tweak]
 
         # named offsets into the pools, all derived from n
@@ -235,8 +247,15 @@ class SharedGroupInputs:
         self.SECNONCE_ZERO_SECOND_IDX = n + 1
         self.OUT_OF_RANGE_ID = n
         # tweaks-pool offsets, n-independent
-        self.OUT_OF_RANGE_TWEAK_IDX = 4
-        self.INFINITY_TWEAK_IDX = 5
+        self.OUT_OF_RANGE_TWEAK_IDX = len(COMMON_TWEAKS)
+        self.INFINITY_TWEAK_IDX = len(COMMON_TWEAKS) + 1
+
+
+def has_excl0_subset(t, n):
+    # The "excl0" subset (a size-t signer set that excludes participant 0) is
+    # usable only when t >= 2 and t < n. At t=n no size-t set can exclude id 0,
+    # and at t=1 all shares are identical, so excluding id 0 changes nothing.
+    return t >= 2 and t < n
 
 
 def get_subset(cfg, strategy="min"):
@@ -249,7 +268,8 @@ def get_subset(cfg, strategy="min"):
             return [0] + list(range(cfg.n - cfg.t + 1, cfg.n))
         case "min2":  # size-at-least-2 baseline; [0, 1] at t=1
             return list(range(max(cfg.t, 2)))
-        case "wrong":  # t ids from 1, excludes id 0 (caller guards t>=2 and t<n)
+        case "excl0":  # t ids from 1, excludes id 0 (only valid when has_excl0_subset)
+            assert has_excl0_subset(cfg.t, cfg.n)
             return list(range(1, cfg.t + 1))
         case _:
             raise ValueError(f"Unknown subset strategy: {strategy}")
@@ -257,18 +277,16 @@ def get_subset(cfg, strategy="min"):
 
 def swap_last_two(indices):
     result = list(indices)
-    if len(result) >= 2:
-        result[-1], result[-2] = result[-2], result[-1]
+    assert len(result) >= 2
+    result[-1], result[-2] = result[-2], result[-1]
     return result
 
 
 def set_group_config(group, cfg, inputs):
-    thresh_pk = pubkey_gen_plain(cfg.seckey)
-    assert thresh_pk == inputs.thresh_pk
     group["tg_id"] = cfg.tg_id
     group["t"] = cfg.t
     group["n"] = cfg.n
-    group["thresh_pk"] = bytes_to_hex(thresh_pk)
+    group["thresh_pk"] = bytes_to_hex(inputs.thresh_pk)
 
 
 def assign_tc_ids(groups):

--- a/python/generators/det_sign.py
+++ b/python/generators/det_sign.py
@@ -12,6 +12,7 @@ from generators.common import (
     COMMON_MSGS,
     COMMON_TWEAKS,
     CONFIGS,
+    AGGNONCE_WRONG_TAG,
     OUT_OF_RANGE_TWEAK,
     SharedGroupInputs,
     assign_tc_ids,
@@ -19,6 +20,7 @@ from generators.common import (
     bytes_to_hex,
     expect_exception,
     get_subset,
+    has_excl0_subset,
     set_group_config,
     swap_last_two,
     write_test_vectors,
@@ -33,9 +35,6 @@ RANDS = [
 
 # Fault literals that are case payloads rather than pool material (config-independent,
 # never indexed from a pool), so they stay local to this generator.
-AGGOTHERNONCE_WRONG_TAG = bytes.fromhex(
-    "048465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61037496A3CC86926D452CAFCFD55D25972CA1675D549310DE296BFF42F72EEEA8C9"
-)
 AGGOTHERNONCE_FIRST_HALF_ZERO = bytes.fromhex(
     "0000000000000000000000000000000000000000000000000000000000000000000287BF891D2A6DEAEBADC909352AA9405D1428C15F4B75F04DAE642A95C2548480"
 )
@@ -49,7 +48,10 @@ AGGOTHERNONCE_EXCEEDS_FIELD = bytes.fromhex(
 
 class DetSignGroupBuilder:
     """Builds one (t, n) test group for det_sign_vectors.json. Shared inputs and
-    subsets live on self. Each add_* method appends its category to self.group."""
+    subsets live on self. Each add_* method appends its category to self.group.
+
+    Index convention: valid cases use secshare_index == my_id (a signer signs with
+    its own share at pool position my_id)."""
 
     def __init__(self, cfg):
         self.inputs = SharedGroupInputs(cfg)
@@ -57,11 +59,11 @@ class DetSignGroupBuilder:
         self.n = self.inputs.n
         self.thresh_pk = self.inputs.thresh_pk
 
+        self.cfg = cfg
         self.min_s = get_subset(cfg, "min")
         self.full = get_subset(cfg, "full")
         self.alt = get_subset(cfg, "alt")
         self.min2 = get_subset(cfg, "min2")
-        self.wrong = get_subset(cfg, "wrong") if cfg.t >= 2 and cfg.t < cfg.n else None
 
         self.group = {}
         set_group_config(self.group, cfg, self.inputs)
@@ -77,9 +79,9 @@ class DetSignGroupBuilder:
         msg: bytes,
         rand: Optional[bytes],
     ) -> Optional[bytes]:
-        """Return None when the signer is the sole participant. Otherwise aggregate
-        the other signers' public nonces."""
-        if len(ids_set) == 1:
+        """Return None when the signer is the sole participant (the set is exactly
+        [my_id]). Otherwise aggregate the other signers' public nonces."""
+        if ids_set == [my_id]:
             return None
         tmp = b"" if rand is None else rand
         other_pubnonces = []
@@ -203,43 +205,32 @@ class DetSignGroupBuilder:
             [],
             "Minimum threshold subset of signers",
         )
-        # reordering. Uses reversed(min2), which is a real reorder in every config.
-        rev_min2 = list(reversed(self.min2))
-        self._append_valid(
-            0,
-            rev_min2,
-            rev_min2,
-            RANDS[0],
-            COMMON_MSGS[0],
-            [],
-            [],
-            "Reordering the signer set leaves the deterministic output unchanged, because the identifiers are sorted before they are bound into the nonce derivation and the binding value",
-        )
-        # a different threshold subset (only when one exists).
-        if t < n:
-            if t == 1:
-                # 1of3: use id 1 as the sole signer (det_sign-local exception).
-                self._append_valid(
-                    1,
-                    [1],
-                    [1],
-                    RANDS[0],
-                    COMMON_MSGS[0],
-                    [],
-                    [],
-                    "A different threshold subset gives a different deterministic nonce, since the signer set is bound into the nonce derivation",
-                )
-            else:
-                self._append_valid(
-                    0,
-                    self.alt,
-                    self.alt,
-                    RANDS[0],
-                    COMMON_MSGS[0],
-                    [],
-                    [],
-                    "A different threshold subset gives a different deterministic nonce, since the signer set is bound into the nonce derivation",
-                )
+        # reordering (needs a set of size >= 2 to be meaningful, matching sign_verify).
+        if t >= 2:
+            rev = list(reversed(self.min_s))
+            self._append_valid(
+                0,
+                rev,
+                rev,
+                RANDS[0],
+                COMMON_MSGS[0],
+                [],
+                [],
+                "Reordering the signer set leaves the deterministic output unchanged, because the identifiers are sorted before they are bound into the nonce derivation and the binding value",
+            )
+        # a different threshold subset (needs t >= 2; at t=1 alt collapses to the
+        # minimum set, matching sign_verify).
+        if t >= 2 and t < n:
+            self._append_valid(
+                0,
+                self.alt,
+                self.alt,
+                RANDS[0],
+                COMMON_MSGS[0],
+                [],
+                [],
+                "A different threshold subset gives a different deterministic nonce, since the signer set is bound into the nonce derivation",
+            )
         # null randomness.
         self._append_valid(
             0,
@@ -339,12 +330,12 @@ class DetSignGroupBuilder:
             "Signer set contains a duplicate id",
         )
         # signer loads share 0 but the set excludes id 0 (needs t >= 2 and t < n).
-        if t >= 2 and t < n:
-            assert self.wrong is not None
+        if has_excl0_subset(t, n):
+            excl0 = get_subset(self.cfg, "excl0")
             self._append_error(
                 1,
-                self.wrong,
-                self.wrong,
+                excl0,
+                excl0,
                 0,
                 RANDS[0],
                 COMMON_MSGS[0],
@@ -372,7 +363,9 @@ class DetSignGroupBuilder:
         )
         # A signer id equals n, outside the valid range. For t >= 2 an in-range
         # member signs. At t=1 the lone id is out of range and the check fires
-        # first, so the self fields are inert.
+        # first, so the self fields are inert. This assumes signer-id range
+        # validation runs before the pubshare/threshold-key checks; a different
+        # order would surface a different error.
         if t >= 2:
             ids_out_of_range = [self.inputs.OUT_OF_RANGE_ID] + list(range(1, t))
             self._append_error(
@@ -400,7 +393,9 @@ class DetSignGroupBuilder:
                 "value",
                 "A signer id is outside the valid range [0, n-1]",
             )
-        # pubshares don't match the threshold public key (needs t >= 2).
+        # pubshares don't match the threshold public key. Needs t >= 2: at t=1 the lone
+        # pubshare must equal the threshold key, so there is no last-two pair to swap. The
+        # 1of3 config intentionally omits this case, matching sign_verify.
         if t >= 2:
             self._append_error(
                 0,
@@ -426,7 +421,7 @@ class DetSignGroupBuilder:
             [],
             "invalid_contrib",
             "Aggregate of the other signers' nonces is invalid: first half has an unknown tag 0x04",
-            aggothernonce=AGGOTHERNONCE_WRONG_TAG,
+            aggothernonce=AGGNONCE_WRONG_TAG,
         )
         self._append_error(
             0,

--- a/python/generators/det_sign.py
+++ b/python/generators/det_sign.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 from frost_ref import (
     InvalidContributionError,
     SignersContext,
@@ -9,357 +11,461 @@ from frost_ref.signing import nonce_gen_internal
 from generators.common import (
     COMMON_MSGS,
     COMMON_TWEAKS,
-    INVALID_PUBSHARE,
+    CONFIGS,
     OUT_OF_RANGE_TWEAK,
-    SECKEY_2OF3,
+    SharedGroupInputs,
+    assign_tc_ids,
     bytes_list_to_hex,
     bytes_to_hex,
     expect_exception,
-    frost_keygen,
+    get_subset,
+    set_group_config,
+    swap_last_two,
     write_test_vectors,
 )
 
+# Aux-randomness pool: all-zeros, None (omitted), all-ones.
+RANDS = [
+    bytes.fromhex("0000000000000000000000000000000000000000000000000000000000000000"),
+    None,
+    bytes.fromhex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"),
+]
 
-def generate_det_sign_vectors():
-    n, t, thresh_pk, ids, secshares, pubshares = frost_keygen(SECKEY_2OF3)
-    xonly_thresh_pk = thresh_pk[1:]
 
-    # Special indices for test cases
-    INVALID_PUBSHARE_IDX = n
-    INVALID_TWEAK_IDX = 1
-    RAND_NONE_IDX = 1
-    RAND_MAX_IDX = 2
+class DetSignGroupBuilder:
+    """Builds one (t, n) test group for det_sign_vectors.json. Each add_* method appends its category to self.group."""
 
-    assert len(COMMON_MSGS[2]) == 38
+    def __init__(self, cfg):
+        self.inputs = SharedGroupInputs(cfg)
+        self.t = self.inputs.t
+        self.n = self.inputs.n
+        self.thresh_pk = self.inputs.thresh_pk
 
-    pubshares.append(INVALID_PUBSHARE)
+        self.min_s = get_subset(cfg, "min")
+        self.full = get_subset(cfg, "full")
+        self.alt = get_subset(cfg, "alt")
+        self.min2 = get_subset(cfg, "min2")
+        self.wrong = get_subset(cfg, "wrong") if cfg.t >= 2 and cfg.t < cfg.n else None
 
-    group = {
-        "tg_id": "2of3",
-        "t": t,
-        "n": n,
-        "thresh_pk": bytes_to_hex(thresh_pk),
-        "pubshares": bytes_list_to_hex(pubshares),
-        "secshares": bytes_list_to_hex(secshares),
-        "valid_tests": [],
-        "error_tests": [],
-    }
-    tc_id = 1
+        self.group = {}
+        set_group_config(self.group, cfg, self.inputs)
+        self.group["pubshares"] = bytes_list_to_hex(self.inputs.pool_pubshares)
+        self.group["secshares"] = bytes_list_to_hex(self.inputs.pool_secshares)
+        self.group["valid_tests"] = []
+        self.group["error_tests"] = []
 
-    rands = [
-        bytes.fromhex(
-            "0000000000000000000000000000000000000000000000000000000000000000"
-        ),
-        None,
-        bytes.fromhex(
-            "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
-        ),
-    ]
-
-    tweaks = [
-        [COMMON_TWEAKS[0]],
-        [OUT_OF_RANGE_TWEAK],
-    ]
-
-    # --- Valid Test Cases ---
-    valid_cases = [
-        {
-            "indices": [0, 1],
-            "my_id": 0,
-            "msg": 0,
-            "rand": 0,
-            "comment": "Minimum threshold subset of signers",
-        },
-        {
-            "indices": [1, 0],
-            "my_id": 0,
-            "msg": 0,
-            "rand": 0,
-            "comment": "Reordering the signer set leaves the deterministic output unchanged, because the identifiers are sorted before they are bound into the nonce derivation and the binding value",
-        },
-        {
-            "indices": [0, 2],
-            "my_id": 0,
-            "msg": 0,
-            "rand": 0,
-            "comment": "A different threshold subset gives a different deterministic nonce, since the signer set is bound into the nonce derivation",
-        },
-        {
-            "indices": [0, 1],
-            "my_id": 0,
-            "msg": 0,
-            "rand": RAND_NONE_IDX,
-            "comment": "Auxiliary randomness omitted (null), which is not equivalent to all-zeros randomness",
-        },
-        {
-            "indices": [0, 1],
-            "my_id": 0,
-            "msg": 0,
-            "rand": RAND_MAX_IDX,
-            "comment": "Auxiliary randomness is all ones, distinct from the all-zeros and omitted cases",
-        },
-        {
-            "indices": [0, 1, 2],
-            "my_id": 1,
-            "msg": 0,
-            "rand": 0,
-            "comment": "All n=3 signers participate, signed by a non-first member of the signer set",
-        },
-        {
-            "indices": [0, 1],
-            "my_id": 0,
-            "msg": 1,
-            "rand": 0,
-            "comment": "Empty message",
-        },
-        {
-            "indices": [0, 1],
-            "my_id": 0,
-            "msg": 2,
-            "rand": 0,
-            "comment": "Non-standard message length (38 bytes)",
-        },
-        {
-            "indices": [0, 1],
-            "my_id": 0,
-            "msg": 0,
-            "rand": 0,
-            "tweaks": 0,
-            "is_xonly": [True],
-            "comment": "Single x-only tweak applied",
-        },
-    ]
-    for case in valid_cases:
-        curr_ids = [ids[i] for i in case["indices"]]
-        curr_pubshares = [pubshares[i] for i in case["indices"]]
-        curr_msg = COMMON_MSGS[case["msg"]]
-        curr_rand = rands[case["rand"]]
-        my_id = case["my_id"]
-        tweaks_idx = case.get("tweaks", None)
-        curr_tweaks = [] if tweaks_idx is None else tweaks[tweaks_idx]
-        curr_tweak_modes = case.get("is_xonly", [])
-        secshare_index = ids.index(my_id)
-
-        # generate `aggothernonce` (every signer's nonce except this signer's own)
+    def _derive_aggothernonce(
+        self,
+        ids_set: List[int],
+        my_id: int,
+        msg: bytes,
+        rand: Optional[bytes],
+    ) -> Optional[bytes]:
+        """Return None when the signer is the sole participant. Otherwise aggregate
+        the other signers' public nonces."""
+        if len(ids_set) == 1:
+            return None
+        tmp = b"" if rand is None else rand
         other_pubnonces = []
-        for i in case["indices"]:
-            if ids[i] == my_id:
+        for pid in ids_set:
+            if pid == my_id:
                 continue
-            tmp = b"" if curr_rand is None else curr_rand
             _, pub = nonce_gen_internal(
-                tmp, secshares[i], pubshares[i], xonly_thresh_pk, curr_msg, None
+                tmp,
+                self.inputs.pool_secshares[pid],
+                self.inputs.pool_pubshares[pid],
+                self.inputs.xonly_thresh_pk,
+                msg,
+                None,
             )
             other_pubnonces.append(pub)
-        curr_aggothernonce = nonce_agg(other_pubnonces)
+        return nonce_agg(other_pubnonces)
 
-        curr_signers = SignersContext(n, t, curr_ids, curr_pubshares, thresh_pk)
-        expected = deterministic_sign(
-            secshares[secshare_index],
-            my_id,
-            curr_aggothernonce,
-            curr_signers,
-            curr_tweaks,
-            curr_tweak_modes,
-            curr_msg,
-            curr_rand,
+    def _append_valid(
+        self,
+        my_id: int,
+        ids: List[int],
+        pubshare_indices: List[int],
+        rand: Optional[bytes],
+        msg: bytes,
+        tweaks: List[bytes],
+        is_xonly: List[bool],
+        comment: str,
+    ) -> None:
+        curr_aggothernonce = self._derive_aggothernonce(ids, my_id, msg, rand)
+        pubshares = [self.inputs.pool_pubshares[i] for i in pubshare_indices]
+        signers = SignersContext(self.n, self.t, ids, pubshares, self.thresh_pk)
+        secshare = self.inputs.pool_secshares[my_id]
+        result = deterministic_sign(
+            secshare, my_id, curr_aggothernonce, signers, tweaks, is_xonly, msg, rand
         )
-
-        group["valid_tests"].append(
+        self.group["valid_tests"].append(
             {
-                "tc_id": tc_id,
-                "comment": case["comment"],
+                "comment": comment,
                 "my_id": my_id,
-                "ids": curr_ids,
-                "pubshare_indices": case["indices"],
-                "secshare_index": secshare_index,
-                "aggothernonce": bytes_to_hex(curr_aggothernonce),
-                "rand": bytes_to_hex(curr_rand) if curr_rand is not None else curr_rand,
-                "msg": bytes_to_hex(curr_msg),
-                "tweaks": bytes_list_to_hex(curr_tweaks),
-                "is_xonly": curr_tweak_modes,
-                "expected": bytes_list_to_hex(expected),
+                "ids": ids,
+                "pubshare_indices": pubshare_indices,
+                "secshare_index": my_id,
+                "aggothernonce": bytes_to_hex(curr_aggothernonce)
+                if curr_aggothernonce is not None
+                else None,
+                "rand": bytes_to_hex(rand) if rand is not None else None,
+                "msg": bytes_to_hex(msg),
+                "tweaks": bytes_list_to_hex(tweaks),
+                "is_xonly": is_xonly,
+                "expected": bytes_list_to_hex(list(result)),
             }
         )
-        tc_id += 1
 
-    # --- Error Test Cases ---
-    error_cases = [
-        {
-            # my_id=2 is outside ids=[0,1]. The signer presents participant 0's
-            # valid in-set material (secshare_index=0), since the id-membership
-            # check is only reached after the pubshare-membership check passes.
-            "ids": [0, 1],
-            "pubshares": [0, 1],
-            "my_id": 2,
-            "secshare_index": 0,
-            "msg": 0,
-            "rand": 0,
-            "error": "value",
-            "comment": "my_id is not in the signer set",
-        },
-        {
-            "ids": [0, 1, 1],
-            "pubshares": [0, 1, 1],
-            "my_id": 0,
-            "secshare_index": 0,
-            "msg": 0,
-            "rand": 0,
-            "error": "value",
-            "comment": "Signer set contains a duplicate id",
-        },
-        {
-            # The signer is set member my_id=1 but loads participant 0's secret
-            # share (secshare_index=0, the single bad field), so the derived public
-            # share is absent from the set {1,2}.
-            "ids": [1, 2],
-            "pubshares": [1, 2],
-            "my_id": 1,
-            "secshare_index": 0,
-            "msg": 0,
-            "rand": 0,
-            "error": "value",
-            "comment": "Signer's public share is not in the public share list",
-        },
-        {
-            "ids": [0, 1],
-            "pubshares": [0, INVALID_PUBSHARE_IDX],
-            "my_id": 0,
-            "secshare_index": 0,
-            "msg": 0,
-            "rand": 0,
-            "error": "value",
-            "comment": "A public share is not a valid point",
-        },
-        {
-            # Context-validation error independent of the secret; align signer to my_id=2.
-            "ids": [2, 1],
-            "pubshares": [0, 1],
-            "my_id": 2,
-            "secshare_index": 2,
-            "msg": 0,
-            "rand": 0,
-            "error": "value",
-            "comment": "Signer set's public shares do not match the threshold public key",
-        },
-        {
-            "ids": [0, 1],
-            "pubshares": [0, 1],
-            "my_id": 0,
-            "secshare_index": 0,
-            "msg": 0,
-            "rand": 0,
-            "aggothernonce": "048465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61037496A3CC86926D452CAFCFD55D25972CA1675D549310DE296BFF42F72EEEA8C9",
-            "error": "invalid_contrib",
-            "comment": "Aggregate of the other signers' nonces is invalid: first half has an unknown tag 0x04",
-        },
-        {
-            "ids": [0, 1],
-            "pubshares": [0, 1],
-            "my_id": 0,
-            "secshare_index": 0,
-            "msg": 0,
-            "rand": 0,
-            "aggothernonce": "0000000000000000000000000000000000000000000000000000000000000000000287BF891D2A6DEAEBADC909352AA9405D1428C15F4B75F04DAE642A95C2548480",
-            "error": "invalid_contrib",
-            "comment": "Aggregate of the other signers' nonces is invalid: first half is all zeros",
-        },
-        {
-            "ids": [0, 1],
-            "pubshares": [0, 1],
-            "my_id": 0,
-            "secshare_index": 0,
-            "msg": 0,
-            "rand": 0,
-            "aggothernonce": "0353BC2314D46C813AF81317AF1BDF99816B6444E416BB8D3DC04ACB2F5388D1AC020000000000000000000000000000000000000000000000000000000000000009",
-            "error": "invalid_contrib",
-            "comment": "Aggregate of the other signers' nonces is invalid: second half is not a point on the curve",
-        },
-        {
-            "ids": [0, 1],
-            "pubshares": [0, 1],
-            "my_id": 0,
-            "secshare_index": 0,
-            "msg": 0,
-            "rand": 0,
-            "aggothernonce": "0353BC2314D46C813AF81317AF1BDF99816B6444E416BB8D3DC04ACB2F5388D1AC02FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30",
-            "error": "invalid_contrib",
-            "comment": "Aggregate of the other signers' nonces is invalid: second half's x-coordinate exceeds the field size",
-        },
-        {
-            "ids": [0, 1],
-            "pubshares": [0, 1],
-            "my_id": 0,
-            "secshare_index": 0,
-            "msg": 0,
-            "rand": 0,
-            "tweaks": INVALID_TWEAK_IDX,
-            "is_xonly": [False],
-            "error": "value",
-            "comment": "Tweak exceeds the group order",
-        },
-    ]
-    for case in error_cases:
-        curr_ids = [ids[i] for i in case["ids"]]
-        curr_pubshares = [pubshares[i] for i in case["pubshares"]]
-        curr_msg = COMMON_MSGS[case["msg"]]
-        curr_rand = rands[case["rand"]]
-        my_id = case["my_id"]
-        secshare_index = case["secshare_index"]
-        tweaks_idx = case.get("tweaks", None)
-        curr_tweaks = [] if tweaks_idx is None else tweaks[tweaks_idx]
-        curr_tweak_modes = case.get("is_xonly", [])
-
-        # generate `aggothernonce` (every signer's nonce except this signer's own)
-        is_aggothernonce = case.get("aggothernonce", None)
-        if is_aggothernonce is None:
-            other_pubnonces = []
-            for i in case["ids"]:
-                if ids[i] == my_id:
-                    continue
-                tmp = b"" if curr_rand is None else curr_rand
-                _, pub = nonce_gen_internal(
-                    tmp, secshares[i], pubshares[i], xonly_thresh_pk, curr_msg, None
-                )
-                other_pubnonces.append(pub)
-            curr_aggothernonce = nonce_agg(other_pubnonces)
+    def _append_error(
+        self,
+        my_id: int,
+        ids: List[int],
+        pubshare_indices: List[int],
+        secshare_index: int,
+        rand: Optional[bytes],
+        msg: bytes,
+        tweaks: List[bytes],
+        is_xonly: List[bool],
+        error: str,
+        comment: str,
+        aggothernonce: Optional[bytes] = None,
+    ) -> None:
+        # A caller may supply a crafted aggothernonce to exercise an error path.
+        curr_aggothernonce: Optional[bytes]
+        if aggothernonce is not None:
+            curr_aggothernonce = aggothernonce
         else:
-            curr_aggothernonce = bytes.fromhex(is_aggothernonce)
-
-        expected_exception = (
-            ValueError if case["error"] == "value" else InvalidContributionError
-        )
-        curr_signers = SignersContext(n, t, curr_ids, curr_pubshares, thresh_pk)
-        error = expect_exception(
+            curr_aggothernonce = self._derive_aggothernonce(ids, my_id, msg, rand)
+        pubshares = [self.inputs.pool_pubshares[i] for i in pubshare_indices]
+        signers = SignersContext(self.n, self.t, ids, pubshares, self.thresh_pk)
+        secshare = self.inputs.pool_secshares[secshare_index]
+        expected_exc = ValueError if error == "value" else InvalidContributionError
+        err = expect_exception(
             lambda: deterministic_sign(
-                secshares[secshare_index],
+                secshare,
                 my_id,
                 curr_aggothernonce,
-                curr_signers,
-                curr_tweaks,
-                curr_tweak_modes,
-                curr_msg,
-                curr_rand,
+                signers,
+                tweaks,
+                is_xonly,
+                msg,
+                rand,
             ),
-            expected_exception,
+            expected_exc,
         )
-
-        group["error_tests"].append(
+        self.group["error_tests"].append(
             {
-                "tc_id": tc_id,
-                "comment": case["comment"],
+                "comment": comment,
                 "my_id": my_id,
-                "ids": curr_ids,
-                "pubshare_indices": case["pubshares"],
+                "ids": ids,
+                "pubshare_indices": pubshare_indices,
                 "secshare_index": secshare_index,
-                "aggothernonce": bytes_to_hex(curr_aggothernonce),
-                "rand": bytes_to_hex(curr_rand) if curr_rand is not None else curr_rand,
-                "msg": bytes_to_hex(curr_msg),
-                "tweaks": bytes_list_to_hex(curr_tweaks),
-                "is_xonly": curr_tweak_modes,
-                "error": error,
+                "aggothernonce": bytes_to_hex(curr_aggothernonce)
+                if curr_aggothernonce is not None
+                else None,
+                "rand": bytes_to_hex(rand) if rand is not None else None,
+                "msg": bytes_to_hex(msg),
+                "tweaks": bytes_list_to_hex(tweaks),
+                "is_xonly": is_xonly,
+                "error": err,
             }
         )
-        tc_id += 1
 
-    vectors = {"test_groups": [group]}
-    write_test_vectors("det_sign_vectors.json", vectors)
+    # --- Array A: valid_tests ---
+
+    def add_valid_tests(self) -> None:
+        t, n = self.t, self.n
+
+        # minimum threshold subset.
+        self._append_valid(
+            0,
+            self.min_s,
+            self.min_s,
+            RANDS[0],
+            COMMON_MSGS[0],
+            [],
+            [],
+            "Minimum threshold subset of signers",
+        )
+        # reordering. Uses reversed(min2), which is a real reorder in every config.
+        rev_min2 = list(reversed(self.min2))
+        self._append_valid(
+            0,
+            rev_min2,
+            rev_min2,
+            RANDS[0],
+            COMMON_MSGS[0],
+            [],
+            [],
+            "Reordering the signer set leaves the deterministic output unchanged, because the identifiers are sorted before they are bound into the nonce derivation and the binding value",
+        )
+        # a different threshold subset (only when one exists).
+        if t < n:
+            if t == 1:
+                # 1of3: use id 1 as the sole signer (det_sign-local exception).
+                self._append_valid(
+                    1,
+                    [1],
+                    [1],
+                    RANDS[0],
+                    COMMON_MSGS[0],
+                    [],
+                    [],
+                    "A different threshold subset gives a different deterministic nonce, since the signer set is bound into the nonce derivation",
+                )
+            else:
+                self._append_valid(
+                    0,
+                    self.alt,
+                    self.alt,
+                    RANDS[0],
+                    COMMON_MSGS[0],
+                    [],
+                    [],
+                    "A different threshold subset gives a different deterministic nonce, since the signer set is bound into the nonce derivation",
+                )
+        # null randomness.
+        self._append_valid(
+            0,
+            self.min_s,
+            self.min_s,
+            RANDS[1],
+            COMMON_MSGS[0],
+            [],
+            [],
+            "Auxiliary randomness omitted (null), which is not equivalent to all-zeros randomness",
+        )
+        # all-ones randomness.
+        self._append_valid(
+            0,
+            self.min_s,
+            self.min_s,
+            RANDS[2],
+            COMMON_MSGS[0],
+            [],
+            [],
+            "Auxiliary randomness is all ones, distinct from the all-zeros and omitted cases",
+        )
+        # all signers, non-first member signs.
+        self._append_valid(
+            1,
+            self.full,
+            self.full,
+            RANDS[0],
+            COMMON_MSGS[0],
+            [],
+            [],
+            "All signers participate, signed by a non-first member of the signer set",
+        )
+        # empty message.
+        self._append_valid(
+            0,
+            self.min_s,
+            self.min_s,
+            RANDS[0],
+            COMMON_MSGS[1],
+            [],
+            [],
+            "Empty message",
+        )
+        # non-standard message length.
+        self._append_valid(
+            0,
+            self.min_s,
+            self.min_s,
+            RANDS[0],
+            COMMON_MSGS[2],
+            [],
+            [],
+            "Non-standard message length (38 bytes)",
+        )
+        # single x-only tweak.
+        self._append_valid(
+            0,
+            self.min_s,
+            self.min_s,
+            RANDS[0],
+            COMMON_MSGS[0],
+            [COMMON_TWEAKS[0]],
+            [True],
+            "Single x-only tweak applied",
+        )
+
+    # --- Array B: error_tests ---
+
+    def add_error_tests(self) -> None:
+        t, n = self.t, self.n
+
+        # my_id is absent from the signer set (only when t < n).
+        if t < n:
+            self._append_error(
+                t,
+                self.min_s,
+                self.min_s,
+                0,
+                RANDS[0],
+                COMMON_MSGS[0],
+                [],
+                [],
+                "value",
+                "my_id is not in the signer set",
+            )
+        # duplicate id in the signer set.
+        self._append_error(
+            0,
+            [0, 1, 1],
+            [0, 1, 1],
+            0,
+            RANDS[0],
+            COMMON_MSGS[0],
+            [],
+            [],
+            "value",
+            "Signer set contains a duplicate id",
+        )
+        # signer loads share 0 but the set excludes id 0 (needs t >= 2 and t < n).
+        if t >= 2 and t < n:
+            assert self.wrong is not None
+            self._append_error(
+                1,
+                self.wrong,
+                self.wrong,
+                0,
+                RANDS[0],
+                COMMON_MSGS[0],
+                [],
+                [],
+                "value",
+                "Signer's public share is not in the public share list",
+            )
+        # off-curve pubshare at position 1 (min2 forces size >= 2).
+        ps13 = [self.min2[0], self.inputs.INVALID_PUBSHARE_IDX] + self.min2[2:]
+        self._append_error(
+            0,
+            self.min2,
+            ps13,
+            0,
+            RANDS[0],
+            COMMON_MSGS[0],
+            [],
+            [],
+            "value",
+            "A public share is not a valid point",
+        )
+        # pubshares don't match the threshold public key (needs t >= 2).
+        if t >= 2:
+            self._append_error(
+                0,
+                self.min_s,
+                swap_last_two(self.min_s),
+                0,
+                RANDS[0],
+                COMMON_MSGS[0],
+                [],
+                [],
+                "value",
+                "Signer set's public shares do not match the threshold public key",
+            )
+        # inline bad aggothernonce literals (bypass the helper).
+        bad_agg15 = bytes.fromhex(
+            "048465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61037496A3CC86926D452CAFCFD55D25972CA1675D549310DE296BFF42F72EEEA8C9"
+        )
+        self._append_error(
+            0,
+            self.min2,
+            self.min2,
+            0,
+            RANDS[0],
+            COMMON_MSGS[0],
+            [],
+            [],
+            "invalid_contrib",
+            "Aggregate of the other signers' nonces is invalid: first half has an unknown tag 0x04",
+            aggothernonce=bad_agg15,
+        )
+        bad_agg16 = bytes.fromhex(
+            "0000000000000000000000000000000000000000000000000000000000000000000287BF891D2A6DEAEBADC909352AA9405D1428C15F4B75F04DAE642A95C2548480"
+        )
+        self._append_error(
+            0,
+            self.min2,
+            self.min2,
+            0,
+            RANDS[0],
+            COMMON_MSGS[0],
+            [],
+            [],
+            "invalid_contrib",
+            "Aggregate of the other signers' nonces is invalid: first half is all zeros",
+            aggothernonce=bad_agg16,
+        )
+        bad_agg17 = bytes.fromhex(
+            "0353BC2314D46C813AF81317AF1BDF99816B6444E416BB8D3DC04ACB2F5388D1AC020000000000000000000000000000000000000000000000000000000000000009"
+        )
+        self._append_error(
+            0,
+            self.min2,
+            self.min2,
+            0,
+            RANDS[0],
+            COMMON_MSGS[0],
+            [],
+            [],
+            "invalid_contrib",
+            "Aggregate of the other signers' nonces is invalid: second half is not a point on the curve",
+            aggothernonce=bad_agg17,
+        )
+        bad_agg18 = bytes.fromhex(
+            "0353BC2314D46C813AF81317AF1BDF99816B6444E416BB8D3DC04ACB2F5388D1AC02FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30"
+        )
+        self._append_error(
+            0,
+            self.min2,
+            self.min2,
+            0,
+            RANDS[0],
+            COMMON_MSGS[0],
+            [],
+            [],
+            "invalid_contrib",
+            "Aggregate of the other signers' nonces is invalid: second half's x-coordinate exceeds the field size",
+            aggothernonce=bad_agg18,
+        )
+        # tweak exceeds the group order.
+        self._append_error(
+            0,
+            self.min_s,
+            self.min_s,
+            0,
+            RANDS[0],
+            COMMON_MSGS[0],
+            [OUT_OF_RANGE_TWEAK],
+            [False],
+            "value",
+            "Tweak exceeds the group order",
+        )
+        # signing with a zero secret share
+        self._append_error(
+            0,
+            self.min_s,
+            self.min_s,
+            self.inputs.SECSHARE_ZERO_IDX,
+            RANDS[0],
+            COMMON_MSGS[0],
+            [],
+            [],
+            "value",
+            "Secret share is out of range (zero)",
+        )
+
+    def build(self) -> dict:
+        self.add_valid_tests()
+        self.add_error_tests()
+        return self.group
+
+
+def generate_det_sign_vectors() -> None:
+    groups = [DetSignGroupBuilder(cfg).build() for cfg in CONFIGS]
+    assign_tc_ids(groups)
+    write_test_vectors("det_sign_vectors.json", {"test_groups": groups})

--- a/python/generators/det_sign.py
+++ b/python/generators/det_sign.py
@@ -68,7 +68,7 @@ def generate_det_sign_vectors():
             "my_id": 0,
             "msg": 0,
             "rand": 0,
-            "comment": "Minimum threshold subset of signers (t=2 of n=3)",
+            "comment": "Minimum threshold subset of signers",
         },
         {
             "indices": [1, 0],

--- a/python/generators/det_sign.py
+++ b/python/generators/det_sign.py
@@ -31,9 +31,25 @@ RANDS = [
     bytes.fromhex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"),
 ]
 
+# Fault literals that are case payloads rather than pool material (config-independent,
+# never indexed from a pool), so they stay local to this generator.
+AGGOTHERNONCE_WRONG_TAG = bytes.fromhex(
+    "048465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61037496A3CC86926D452CAFCFD55D25972CA1675D549310DE296BFF42F72EEEA8C9"
+)
+AGGOTHERNONCE_FIRST_HALF_ZERO = bytes.fromhex(
+    "0000000000000000000000000000000000000000000000000000000000000000000287BF891D2A6DEAEBADC909352AA9405D1428C15F4B75F04DAE642A95C2548480"
+)
+AGGOTHERNONCE_BAD_POINT = bytes.fromhex(
+    "0353BC2314D46C813AF81317AF1BDF99816B6444E416BB8D3DC04ACB2F5388D1AC020000000000000000000000000000000000000000000000000000000000000009"
+)
+AGGOTHERNONCE_EXCEEDS_FIELD = bytes.fromhex(
+    "0353BC2314D46C813AF81317AF1BDF99816B6444E416BB8D3DC04ACB2F5388D1AC02FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30"
+)
+
 
 class DetSignGroupBuilder:
-    """Builds one (t, n) test group for det_sign_vectors.json. Each add_* method appends its category to self.group."""
+    """Builds one (t, n) test group for det_sign_vectors.json. Shared inputs and
+    subsets live on self. Each add_* method appends its category to self.group."""
 
     def __init__(self, cfg):
         self.inputs = SharedGroupInputs(cfg)
@@ -176,7 +192,6 @@ class DetSignGroupBuilder:
 
     def add_valid_tests(self) -> None:
         t, n = self.t, self.n
-
         # minimum threshold subset.
         self._append_valid(
             0,
@@ -296,7 +311,6 @@ class DetSignGroupBuilder:
 
     def add_error_tests(self) -> None:
         t, n = self.t, self.n
-
         # my_id is absent from the signer set (only when t < n).
         if t < n:
             self._append_error(
@@ -309,7 +323,7 @@ class DetSignGroupBuilder:
                 [],
                 [],
                 "value",
-                "my_id is not in the signer set",
+                "Signer's identifier is absent from the signer set",
             )
         # duplicate id in the signer set.
         self._append_error(
@@ -340,11 +354,14 @@ class DetSignGroupBuilder:
                 "Signer's public share is not in the public share list",
             )
         # off-curve pubshare at position 1 (min2 forces size >= 2).
-        ps13 = [self.min2[0], self.inputs.INVALID_PUBSHARE_IDX] + self.min2[2:]
+        pubshare_indices_offcurve = [
+            self.min2[0],
+            self.inputs.INVALID_PUBSHARE_IDX,
+        ] + self.min2[2:]
         self._append_error(
             0,
             self.min2,
-            ps13,
+            pubshare_indices_offcurve,
             0,
             RANDS[0],
             COMMON_MSGS[0],
@@ -353,6 +370,36 @@ class DetSignGroupBuilder:
             "value",
             "A public share is not a valid point",
         )
+        # A signer id equals n, outside the valid range. For t >= 2 an in-range
+        # member signs. At t=1 the lone id is out of range and the check fires
+        # first, so the self fields are inert.
+        if t >= 2:
+            ids_out_of_range = [self.inputs.OUT_OF_RANGE_ID] + list(range(1, t))
+            self._append_error(
+                1,
+                ids_out_of_range,
+                list(range(t)),
+                1,
+                RANDS[0],
+                COMMON_MSGS[0],
+                [],
+                [],
+                "value",
+                "A signer id is outside the valid range [0, n-1]",
+            )
+        elif t == 1:
+            self._append_error(
+                0,
+                [self.inputs.OUT_OF_RANGE_ID],
+                [0],
+                0,
+                RANDS[0],
+                COMMON_MSGS[0],
+                [],
+                [],
+                "value",
+                "A signer id is outside the valid range [0, n-1]",
+            )
         # pubshares don't match the threshold public key (needs t >= 2).
         if t >= 2:
             self._append_error(
@@ -367,10 +414,7 @@ class DetSignGroupBuilder:
                 "value",
                 "Signer set's public shares do not match the threshold public key",
             )
-        # inline bad aggothernonce literals (bypass the helper).
-        bad_agg15 = bytes.fromhex(
-            "048465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61037496A3CC86926D452CAFCFD55D25972CA1675D549310DE296BFF42F72EEEA8C9"
-        )
+        # Bad aggothernonce literals passed directly to bypass the helper.
         self._append_error(
             0,
             self.min2,
@@ -382,10 +426,7 @@ class DetSignGroupBuilder:
             [],
             "invalid_contrib",
             "Aggregate of the other signers' nonces is invalid: first half has an unknown tag 0x04",
-            aggothernonce=bad_agg15,
-        )
-        bad_agg16 = bytes.fromhex(
-            "0000000000000000000000000000000000000000000000000000000000000000000287BF891D2A6DEAEBADC909352AA9405D1428C15F4B75F04DAE642A95C2548480"
+            aggothernonce=AGGOTHERNONCE_WRONG_TAG,
         )
         self._append_error(
             0,
@@ -398,10 +439,7 @@ class DetSignGroupBuilder:
             [],
             "invalid_contrib",
             "Aggregate of the other signers' nonces is invalid: first half is all zeros",
-            aggothernonce=bad_agg16,
-        )
-        bad_agg17 = bytes.fromhex(
-            "0353BC2314D46C813AF81317AF1BDF99816B6444E416BB8D3DC04ACB2F5388D1AC020000000000000000000000000000000000000000000000000000000000000009"
+            aggothernonce=AGGOTHERNONCE_FIRST_HALF_ZERO,
         )
         self._append_error(
             0,
@@ -414,10 +452,7 @@ class DetSignGroupBuilder:
             [],
             "invalid_contrib",
             "Aggregate of the other signers' nonces is invalid: second half is not a point on the curve",
-            aggothernonce=bad_agg17,
-        )
-        bad_agg18 = bytes.fromhex(
-            "0353BC2314D46C813AF81317AF1BDF99816B6444E416BB8D3DC04ACB2F5388D1AC02FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30"
+            aggothernonce=AGGOTHERNONCE_BAD_POINT,
         )
         self._append_error(
             0,
@@ -430,7 +465,7 @@ class DetSignGroupBuilder:
             [],
             "invalid_contrib",
             "Aggregate of the other signers' nonces is invalid: second half's x-coordinate exceeds the field size",
-            aggothernonce=bad_agg18,
+            aggothernonce=AGGOTHERNONCE_EXCEEDS_FIELD,
         )
         # tweak exceeds the group order.
         self._append_error(
@@ -444,6 +479,20 @@ class DetSignGroupBuilder:
             [False],
             "value",
             "Tweak exceeds the group order",
+        )
+        # Fewer signers than the threshold (empty set at t=1).
+        below = list(range(t - 1))
+        self._append_error(
+            0,
+            below,
+            below,
+            0,
+            RANDS[0],
+            COMMON_MSGS[0],
+            [],
+            [],
+            "value",
+            "Fewer signers than the threshold t",
         )
         # signing with a zero secret share
         self._append_error(

--- a/python/generators/sig_agg.py
+++ b/python/generators/sig_agg.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from frost_ref import (
     InvalidContributionError,
     SessionContext,
@@ -50,10 +52,14 @@ class SigAggGroupBuilder:
         self.group["valid_tests"] = []
         self.group["error_tests"] = []
 
-    def _agg(self, set_indices):
-        return nonce_agg([self.inputs.pubnonces[i] for i in set_indices])
-
-    def _append_valid(self, set_indices, tweak_indices, is_xonly, msg, comment):
+    def _append_valid(
+        self,
+        set_indices: List[int],
+        tweak_indices: List[int],
+        is_xonly: List[bool],
+        msg: bytes,
+        comment: str,
+    ) -> None:
         pubshares = [self.inputs.pubshares[i] for i in set_indices]
         pubnonces = [self.inputs.pubnonces[i] for i in set_indices]
         ids = list(set_indices)
@@ -88,7 +94,9 @@ class SigAggGroupBuilder:
             }
         )
 
-    def _append_error(self, set_indices, fault, error, comment):
+    def _append_error(
+        self, set_indices: List[int], fault: str, error: str, comment: str
+    ) -> None:
         pubshares = [self.inputs.pubshares[i] for i in set_indices]
         pubnonces = [self.inputs.pubnonces[i] for i in set_indices]
         ids = list(set_indices)
@@ -114,12 +122,8 @@ class SigAggGroupBuilder:
         elif fault == "psig_count_mismatch":
             psigs = psigs[:-1]
 
-        expected_exception = (
-            ValueError if error == "value" else InvalidContributionError
-        )
-        err = expect_exception(
-            lambda: partial_sig_agg(psigs, session), expected_exception
-        )
+        expected_exc = ValueError if error == "value" else InvalidContributionError
+        err = expect_exception(lambda: partial_sig_agg(psigs, session), expected_exc)
         self.group["error_tests"].append(
             {
                 "comment": comment,
@@ -136,7 +140,7 @@ class SigAggGroupBuilder:
 
     # --- Array A: valid_tests ---
 
-    def add_valid_tests(self):
+    def add_valid_tests(self) -> None:
         t, n = self.t, self.n
         # Minimum threshold subset.
         self._append_valid(
@@ -178,7 +182,7 @@ class SigAggGroupBuilder:
 
     # --- Array B: error_tests ---
 
-    def add_error_tests(self):
+    def add_error_tests(self) -> None:
         # Partial signature equals the group order (out-of-range scalar).
         self._append_error(
             self.min_s,
@@ -194,13 +198,13 @@ class SigAggGroupBuilder:
             "Number of partial signatures does not match the number of signers",
         )
 
-    def build(self):
+    def build(self) -> dict:
         self.add_valid_tests()
         self.add_error_tests()
         return self.group
 
 
-def generate_sig_agg_vectors():
+def generate_sig_agg_vectors() -> None:
     groups = [SigAggGroupBuilder(cfg).build() for cfg in CONFIGS]
     assign_tc_ids(groups)
     write_test_vectors("sig_agg_vectors.json", {"test_groups": groups})

--- a/python/generators/sig_agg.py
+++ b/python/generators/sig_agg.py
@@ -10,176 +10,197 @@ from frost_ref import (
 
 from generators.common import (
     COMMON_MSGS,
-    COMMON_RAND,
     COMMON_TWEAKS,
-    SECKEY_2OF3,
+    CONFIGS,
+    SharedGroupInputs,
+    assign_tc_ids,
     bytes_list_to_hex,
     bytes_to_hex,
     expect_exception,
-    frost_keygen,
-    generate_all_nonces,
+    get_subset,
+    set_group_config,
     write_test_vectors,
 )
 
+# Fault literals that are case payloads rather than pool material (config-independent,
+# never indexed from a pool), so they stay local to this generator.
+GROUP_ORDER_PSIG = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
 
-def generate_sig_agg_vectors():
-    n, t, thresh_pk, ids, secshares, pubshares = frost_keygen(SECKEY_2OF3)
-    xonly_thresh_pk = thresh_pk[1:]
 
-    secnonces, pubnonces = generate_all_nonces(
-        COMMON_RAND, secshares, pubshares, xonly_thresh_pk
-    )
+class SigAggGroupBuilder:
+    """Builds one (t, n) test group for sig_agg_vectors.json. Shared inputs and
+    subsets live on self. Each add_* method appends its category to self.group."""
 
-    msg = COMMON_MSGS[0]
+    def __init__(self, cfg):
+        self.inputs = SharedGroupInputs(cfg)
+        self.t = self.inputs.t
+        self.n = self.inputs.n
+        self.thresh_pk = self.inputs.thresh_pk
 
-    group = {
-        "tg_id": "2of3",
-        "t": t,
-        "n": n,
-        "thresh_pk": bytes_to_hex(thresh_pk),
-        "pubshares": bytes_list_to_hex(pubshares),
-        "tweaks": bytes_list_to_hex(COMMON_TWEAKS),
-        "valid_tests": [],
-        "error_tests": [],
-    }
-    tc_id = 1
+        self.min_s = get_subset(cfg, "min")
+        self.full = get_subset(cfg, "full")
 
-    # --- Valid Test Cases ---
-    valid_cases = [
-        {
-            "indices": [0, 1],
-            "comment": "Minimum threshold subset of signers, no tweaks",
-        },
-        {
-            "indices": [1, 0],
-            "comment": "Reordering the signer set leaves the aggregate signature unchanged, because the partial signatures are summed and the identifiers are sorted before they are bound into the binding value",
-        },
-        {
-            "indices": [0, 1],
-            "tweaks": [0, 1, 2],
-            "is_xonly": [True, False, False],
-            "comment": "Aggregation with three tweaks applied (one x-only, two plain)",
-        },
-        {
-            "indices": [0, 1, 2],
-            "comment": "All n=3 signers participate, no tweaks",
-        },
-    ]
-    for case in valid_cases:
-        curr_ids = [ids[i] for i in case["indices"]]
-        curr_pubshares = [pubshares[i] for i in case["indices"]]
-        curr_pubnonces = [pubnonces[i] for i in case["indices"]]
-        curr_aggnonce = nonce_agg(curr_pubnonces)
-        curr_msg = msg
-        tweak_indices = case.get("tweaks", [])
-        curr_tweaks = [COMMON_TWEAKS[i] for i in tweak_indices]
-        curr_tweak_modes = case.get("is_xonly", [])
+        self.group = {}
+        set_group_config(self.group, cfg, self.inputs)
+        # sig_agg has no appended fault slots in any pool (both error faults are
+        # injected inline), so the group serializes and reads the plain n-length
+        # pubshares and the 4 common tweaks, not the SharedGroupInputs pool_* arrays.
+        self.group["pubshares"] = bytes_list_to_hex(self.inputs.pubshares)
+        self.group["tweaks"] = bytes_list_to_hex(COMMON_TWEAKS)
+        self.group["valid_tests"] = []
+        self.group["error_tests"] = []
+
+    def _agg(self, set_indices):
+        return nonce_agg([self.inputs.pubnonces[i] for i in set_indices])
+
+    def _append_valid(self, set_indices, tweak_indices, is_xonly, msg, comment):
+        pubshares = [self.inputs.pubshares[i] for i in set_indices]
+        pubnonces = [self.inputs.pubnonces[i] for i in set_indices]
+        ids = list(set_indices)
+        aggnonce = nonce_agg(pubnonces)
+        tweaks = [COMMON_TWEAKS[i] for i in tweak_indices]
+        signers = SignersContext(self.n, self.t, ids, pubshares, self.thresh_pk)
+        session = SessionContext(aggnonce, signers, tweaks, is_xonly, msg)
         psigs = []
-        curr_signers = SignersContext(n, t, curr_ids, curr_pubshares, thresh_pk)
-        session_ctx = SessionContext(
-            curr_aggnonce,
-            curr_signers,
-            curr_tweaks,
-            curr_tweak_modes,
-            curr_msg,
-        )
-        for signer_index, i in enumerate(case["indices"]):
-            my_id = ids[i]
-            sig = sign(bytearray(secnonces[i]), secshares[i], my_id, session_ctx)
-            psigs.append(sig)
-            assert partial_sig_verify(
-                sig,
-                curr_pubnonces,
-                curr_signers,
-                curr_tweaks,
-                curr_tweak_modes,
-                curr_msg,
-                signer_index,
+        for signer_index, my_id in enumerate(set_indices):
+            psig = sign(
+                bytearray(self.inputs.secnonces[my_id]),
+                self.inputs.secshares[my_id],
+                my_id,
+                session,
             )
-        bip340_sig = partial_sig_agg(psigs, session_ctx)
-        group["valid_tests"].append(
+            psigs.append(psig)
+            assert partial_sig_verify(
+                psig, pubnonces, signers, tweaks, is_xonly, msg, signer_index
+            )
+        expected = partial_sig_agg(psigs, session)
+        self.group["valid_tests"].append(
             {
-                "tc_id": tc_id,
-                "comment": case["comment"],
-                "ids": curr_ids,
-                "pubshare_indices": case["indices"],
-                "aggnonce": bytes_to_hex(curr_aggnonce),
+                "comment": comment,
+                "ids": ids,
+                "pubshare_indices": list(set_indices),
+                "aggnonce": bytes_to_hex(aggnonce),
                 "tweak_indices": tweak_indices,
-                "is_xonly": curr_tweak_modes,
+                "is_xonly": is_xonly,
                 "psigs": bytes_list_to_hex(psigs),
-                "msg": bytes_to_hex(curr_msg),
-                "expected": bytes_to_hex(bip340_sig),
+                "msg": bytes_to_hex(msg),
+                "expected": bytes_to_hex(expected),
             }
         )
-        tc_id += 1
 
-    # --- Error Test Cases ---
-    error_cases = [
-        {
-            "indices": [0, 1],
-            "fault": "psig_out_of_range",
-            "error": "invalid_contrib",
-            "comment": "Partial signature equals the group order, which is out of range",
-        },
-        {
-            "indices": [0, 1],
-            "fault": "psig_count_mismatch",
-            "error": "value",
-            "comment": "Number of partial signatures does not match the number of signers",
-        },
-    ]
-    for case in error_cases:
-        curr_ids = [ids[i] for i in case["indices"]]
-        curr_pubshares = [pubshares[i] for i in case["indices"]]
-        curr_pubnonces = [pubnonces[i] for i in case["indices"]]
-        curr_aggnonce = nonce_agg(curr_pubnonces)
-        curr_msg = msg
+    def _append_error(self, set_indices, fault, error, comment):
+        pubshares = [self.inputs.pubshares[i] for i in set_indices]
+        pubnonces = [self.inputs.pubnonces[i] for i in set_indices]
+        ids = list(set_indices)
+        aggnonce = nonce_agg(pubnonces)
+        msg = COMMON_MSGS[0]
+        signers = SignersContext(self.n, self.t, ids, pubshares, self.thresh_pk)
+        session = SessionContext(aggnonce, signers, [], [], msg)
         psigs = []
-        curr_signers = SignersContext(n, t, curr_ids, curr_pubshares, thresh_pk)
-        session_ctx = SessionContext(curr_aggnonce, curr_signers, [], [], curr_msg)
-        for signer_index, i in enumerate(case["indices"]):
-            my_id = ids[i]
-            sig = sign(bytearray(secnonces[i]), secshares[i], my_id, session_ctx)
-            psigs.append(sig)
+        for signer_index, my_id in enumerate(set_indices):
+            psig = sign(
+                bytearray(self.inputs.secnonces[my_id]),
+                self.inputs.secshares[my_id],
+                my_id,
+                session,
+            )
+            psigs.append(psig)
             assert partial_sig_verify(
-                sig,
-                curr_pubnonces,
-                curr_signers,
-                [],
-                [],
-                curr_msg,
-                signer_index,
+                psig, pubnonces, signers, [], [], msg, signer_index
             )
 
-        if case["fault"] == "psig_out_of_range":
-            invalid_psig = bytes.fromhex(
-                "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
-            )
-            psigs[1] = invalid_psig
-        elif case["fault"] == "psig_count_mismatch":
+        if fault == "psig_out_of_range":
+            psigs[-1] = bytes.fromhex(GROUP_ORDER_PSIG)
+        elif fault == "psig_count_mismatch":
             psigs = psigs[:-1]
 
         expected_exception = (
-            ValueError if case["error"] == "value" else InvalidContributionError
+            ValueError if error == "value" else InvalidContributionError
         )
-        error = expect_exception(
-            lambda: partial_sig_agg(psigs, session_ctx), expected_exception
+        err = expect_exception(
+            lambda: partial_sig_agg(psigs, session), expected_exception
         )
-        group["error_tests"].append(
+        self.group["error_tests"].append(
             {
-                "tc_id": tc_id,
-                "comment": case["comment"],
-                "ids": curr_ids,
-                "pubshare_indices": case["indices"],
-                "aggnonce": bytes_to_hex(curr_aggnonce),
+                "comment": comment,
+                "ids": ids,
+                "pubshare_indices": list(set_indices),
+                "aggnonce": bytes_to_hex(aggnonce),
                 "tweak_indices": [],
                 "is_xonly": [],
                 "psigs": bytes_list_to_hex(psigs),
-                "msg": bytes_to_hex(curr_msg),
-                "error": error,
+                "msg": bytes_to_hex(msg),
+                "error": err,
             }
         )
-        tc_id += 1
 
-    vectors = {"test_groups": [group]}
-    write_test_vectors("sig_agg_vectors.json", vectors)
+    # --- Array A: valid_tests ---
+
+    def add_valid_tests(self):
+        t, n = self.t, self.n
+        # Minimum threshold subset.
+        self._append_valid(
+            self.min_s,
+            [],
+            [],
+            COMMON_MSGS[0],
+            "Minimum threshold subset of signers, no tweaks",
+        )
+        # Order-invariance (needs a set of size >= 2 to be meaningful).
+        if t >= 2:
+            rev = list(reversed(self.min_s))
+            self._append_valid(
+                rev,
+                [],
+                [],
+                COMMON_MSGS[0],
+                "Reordering the signer set leaves the aggregate signature unchanged, because the partial signatures are summed and the identifiers are sorted before they are bound into the binding value",
+            )
+        # Three tweaks applied (one x-only, two plain).
+        self._append_valid(
+            self.min_s,
+            [0, 1, 2],
+            [True, False, False],
+            COMMON_MSGS[0],
+            "Aggregation with three tweaks applied (one x-only, two plain)",
+        )
+        # All n signers participate (dropped when t == n, as the all-n set
+        # equals the minimum set and partial_sig_agg has no my_id field, so the
+        # aggregate signature would be byte-identical to the minimum-subset case).
+        if t < n:
+            self._append_valid(
+                self.full,
+                [],
+                [],
+                COMMON_MSGS[0],
+                "All signers participate, no tweaks",
+            )
+
+    # --- Array B: error_tests ---
+
+    def add_error_tests(self):
+        # Partial signature equals the group order (out-of-range scalar).
+        self._append_error(
+            self.min_s,
+            "psig_out_of_range",
+            "invalid_contrib",
+            "Partial signature equals the group order, which is out of range",
+        )
+        # Number of partial signatures does not match the number of signers.
+        self._append_error(
+            self.min_s,
+            "psig_count_mismatch",
+            "value",
+            "Number of partial signatures does not match the number of signers",
+        )
+
+    def build(self):
+        self.add_valid_tests()
+        self.add_error_tests()
+        return self.group
+
+
+def generate_sig_agg_vectors():
+    groups = [SigAggGroupBuilder(cfg).build() for cfg in CONFIGS]
+    assign_tc_ids(groups)
+    write_test_vectors("sig_agg_vectors.json", {"test_groups": groups})

--- a/python/generators/sig_agg.py
+++ b/python/generators/sig_agg.py
@@ -14,6 +14,7 @@ from generators.common import (
     COMMON_MSGS,
     COMMON_TWEAKS,
     CONFIGS,
+    GROUP_ORDER,
     SharedGroupInputs,
     assign_tc_ids,
     bytes_list_to_hex,
@@ -24,14 +25,13 @@ from generators.common import (
     write_test_vectors,
 )
 
-# Fault literals that are case payloads rather than pool material (config-independent,
-# never indexed from a pool), so they stay local to this generator.
-GROUP_ORDER_PSIG = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
-
 
 class SigAggGroupBuilder:
     """Builds one (t, n) test group for sig_agg_vectors.json. Shared inputs and
-    subsets live on self. Each add_* method appends its category to self.group."""
+    subsets live on self. Each add_* method appends its category to self.group.
+
+    Index convention: set_indices selects the signing subset from the pool (sig_agg
+    has no per-signer my_id material convention and no appended fault slots)."""
 
     def __init__(self, cfg):
         self.inputs = SharedGroupInputs(cfg)
@@ -118,7 +118,7 @@ class SigAggGroupBuilder:
             )
 
         if fault == "psig_out_of_range":
-            psigs[-1] = bytes.fromhex(GROUP_ORDER_PSIG)
+            psigs[-1] = GROUP_ORDER
         elif fault == "psig_count_mismatch":
             psigs = psigs[:-1]
 

--- a/python/generators/sig_agg.py
+++ b/python/generators/sig_agg.py
@@ -48,7 +48,7 @@ def generate_sig_agg_vectors():
     valid_cases = [
         {
             "indices": [0, 1],
-            "comment": "Minimum threshold subset of signers (t=2 of n=3), no tweaks",
+            "comment": "Minimum threshold subset of signers, no tweaks",
         },
         {
             "indices": [1, 0],

--- a/python/generators/sign_verify.py
+++ b/python/generators/sign_verify.py
@@ -13,12 +13,15 @@ from secp256k1lab.secp256k1 import Scalar
 from generators.common import (
     COMMON_MSGS,
     CONFIGS,
+    GROUP_ORDER,
+    AGGNONCE_WRONG_TAG,
     SharedGroupInputs,
     assign_tc_ids,
     bytes_list_to_hex,
     bytes_to_hex,
     expect_exception,
     get_subset,
+    has_excl0_subset,
     set_group_config,
     swap_last_two,
     write_test_vectors,
@@ -26,21 +29,21 @@ from generators.common import (
 
 # Fault literals that are case payloads rather than pool material (config-independent,
 # never indexed from a pool), so they stay local to this generator.
-AGGNONCE_WRONG_TAG = bytes.fromhex(
-    "048465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61037496A3CC86926D452CAFCFD55D25972CA1675D549310DE296BFF42F72EEEA8C9"
-)
 AGGNONCE_BAD_XCOORD = bytes.fromhex(
     "028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61020000000000000000000000000000000000000000000000000000000000000009"
 )
 AGGNONCE_EXCEEDS_FIELD = bytes.fromhex(
     "028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD6102FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30"
 )
-GROUP_ORDER_PSIG = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
 
 
 class SignVerifyGroupBuilder:
     """Builds one (t, n) test group for sign_verify_vectors.json. Shared inputs and
-    subsets live on self. Each add_* method appends its category to self.group."""
+    subsets live on self. Each add_* method appends its category to self.group.
+
+    Index convention: valid cases use secshare_index == secnonce_index == my_id (a
+    signer signs with its own material at pool position my_id), and verify-side cases
+    use signer 0's material as the base partial signature."""
 
     def __init__(self, cfg):
         self.inputs = SharedGroupInputs(cfg)
@@ -48,14 +51,11 @@ class SignVerifyGroupBuilder:
         self.n = self.inputs.n
         self.thresh_pk = self.inputs.thresh_pk
 
+        self.cfg = cfg
         self.min_s = get_subset(cfg, "min")
         self.full = get_subset(cfg, "full")
         self.alt = get_subset(cfg, "alt")
         self.min2 = get_subset(cfg, "min2")
-        # `wrong` is only consumed by configs where it stays in range and a valid
-        # participant can sit outside the only valid set (t >= 2 and t < n).
-        # Outside that range it would index the out-of-range slot, so don't build it.
-        self.wrong = get_subset(cfg, "wrong") if cfg.t >= 2 and cfg.t < cfg.n else None
         self.aggnonce_min = self._agg(self.min_s)
 
         self.group = {}
@@ -313,17 +313,18 @@ class SignVerifyGroupBuilder:
             "value",
             "Signer set contains a duplicate id",
         )
-        # Signer loads the wrong share so its derived pubshare is absent (needs
-        # t >= 2 for distinct shares and t < n for a participant outside the set).
-        if t >= 2 and t < n:
-            assert self.wrong is not None
+        # Signer loads share 0 but the set excludes id 0, so its derived pubshare
+        # is absent (needs t >= 2 for distinct shares and t < n for a participant
+        # outside the set).
+        if has_excl0_subset(t, n):
+            excl0 = get_subset(self.cfg, "excl0")
             self._append_sign_error(
                 1,
-                self.wrong,
-                self.wrong,
+                excl0,
+                excl0,
                 0,
                 0,
-                self._agg(self.wrong),
+                self._agg(excl0),
                 COMMON_MSGS[0],
                 "value",
                 "Signer's public share is not in the public share list",
@@ -346,7 +347,9 @@ class SignVerifyGroupBuilder:
         )
         # A signer id equals n, outside the valid range. For t >= 2 an in-range
         # member signs. At t=1 the lone id is out of range and the check fires
-        # first, so the self fields are inert.
+        # first, so the self fields are inert. This assumes signer-id range
+        # validation runs before the pubshare/threshold-key checks; a different
+        # order would surface a different error.
         if t >= 2:
             ids_out_of_range = [self.inputs.OUT_OF_RANGE_ID] + list(range(1, t))
             self._append_sign_error(
@@ -444,7 +447,9 @@ class SignVerifyGroupBuilder:
             "value",
             "Secret nonce's second half is out of range (zero)",
         )
-        # Fewer signers than the threshold (empty set at t=1).
+        # Fewer signers than the threshold (empty set at t=1). The aggnonce, secshare,
+        # and secnonce fields are inert placeholders: SignersContext rejects the
+        # sub-threshold set before sign() reads them.
         below = list(range(t - 1))
         self._append_sign_error(
             0,
@@ -473,7 +478,10 @@ class SignVerifyGroupBuilder:
     # --- Array C: verify_fail_tests ---
 
     def add_verify_fail_tests(self) -> None:
-        # Base partial signature: signer 0 over the size-at-least-2 baseline set.
+        # Base partial signature: signer 0 over min2, the size-at-least-2 baseline set.
+        # min2 (not min_s) because the wrong-signer-index fail case below verifies at
+        # signer_index 1, which needs a 2-signer set. min2 == min_s for t >= 2, so this
+        # only differs at t=1.
         secnonce = bytearray(self.inputs.pool_secnonces[0])
         signers = SignersContext(
             self.n,
@@ -507,7 +515,7 @@ class SignVerifyGroupBuilder:
             self.min2,
             self.min2,
             0,
-            bytes.fromhex(GROUP_ORDER_PSIG),
+            GROUP_ORDER,
             "Partial signature equals the group order, which is out of range",
         )
 

--- a/python/generators/sign_verify.py
+++ b/python/generators/sign_verify.py
@@ -6,518 +6,542 @@ from frost_ref import (
     partial_sig_verify,
     sign,
 )
-from secp256k1lab.secp256k1 import GE, Scalar
+from secp256k1lab.secp256k1 import Scalar
 
 from generators.common import (
     COMMON_MSGS,
-    COMMON_RAND,
-    INVALID_PUBSHARE,
-    SECKEY_2OF3,
+    CONFIGS,
+    SharedGroupInputs,
+    assign_tc_ids,
     bytes_list_to_hex,
     bytes_to_hex,
     expect_exception,
-    frost_keygen,
-    generate_all_nonces,
+    get_subset,
+    set_group_config,
+    swap_last_two,
     write_test_vectors,
 )
 
+# Fault literals that are case payloads rather than pool material (config-independent,
+# never indexed from a pool), so they stay local to this generator.
+AGGNONCE_WRONG_TAG = bytes.fromhex(
+    "048465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61037496A3CC86926D452CAFCFD55D25972CA1675D549310DE296BFF42F72EEEA8C9"
+)
+AGGNONCE_BAD_XCOORD = bytes.fromhex(
+    "028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61020000000000000000000000000000000000000000000000000000000000000009"
+)
+AGGNONCE_EXCEEDS_FIELD = bytes.fromhex(
+    "028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD6102FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30"
+)
+GROUP_ORDER_PSIG = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
+
+
+class SignVerifyGroupBuilder:
+    """Builds one (t, n) test group for sign_verify_vectors.json. Shared inputs and
+    subsets live on self. Each add_* method appends its category to self.group."""
+
+    def __init__(self, cfg):
+        self.inputs = SharedGroupInputs(cfg)
+        self.t = self.inputs.t
+        self.n = self.inputs.n
+        self.thresh_pk = self.inputs.thresh_pk
+
+        self.min_s = get_subset(cfg, "min")
+        self.full = get_subset(cfg, "full")
+        self.alt = get_subset(cfg, "alt")
+        self.min2 = get_subset(cfg, "min2")
+        # `wrong` is only consumed by configs where it stays in range and a valid
+        # participant can sit outside the only valid set (t >= 2 and t < n).
+        # Outside that range it would index the out-of-range slot, so don't build it.
+        self.wrong = get_subset(cfg, "wrong") if cfg.t >= 2 and cfg.t < cfg.n else None
+        self.aggnonce_min = self._agg(self.min_s)
+
+        self.group = {}
+        set_group_config(self.group, cfg, self.inputs)
+        self.group["pubshares"] = bytes_list_to_hex(self.inputs.pool_pubshares)
+        self.group["pubnonces"] = bytes_list_to_hex(self.inputs.pool_pubnonces)
+        self.group["secshares"] = bytes_list_to_hex(self.inputs.pool_secshares)
+        self.group["secnonces"] = bytes_list_to_hex(self.inputs.pool_secnonces)
+        self.group["valid_tests"] = []
+        self.group["sign_error_tests"] = []
+        self.group["verify_fail_tests"] = []
+        self.group["verify_error_tests"] = []
+
+    def _agg(self, pubnonce_indices):
+        return nonce_agg([self.inputs.pool_pubnonces[i] for i in pubnonce_indices])
+
+    def _append_valid(
+        self, my_id, ids, pubshare_indices, pubnonce_indices, aggnonce, msg, comment
+    ):
+        pubshares = [self.inputs.pool_pubshares[i] for i in pubshare_indices]
+        pubnonces = [self.inputs.pool_pubnonces[i] for i in pubnonce_indices]
+        secnonce = bytearray(self.inputs.pool_secnonces[my_id])
+        signers = SignersContext(self.n, self.t, ids, pubshares, self.thresh_pk)
+        session = SessionContext(aggnonce, signers, [], [], msg)
+        psig = sign(secnonce, self.inputs.pool_secshares[my_id], my_id, session)
+        assert partial_sig_verify(
+            psig, pubnonces, signers, [], [], msg, ids.index(my_id)
+        )
+        self.group["valid_tests"].append(
+            {
+                "comment": comment,
+                "my_id": my_id,
+                "ids": ids,
+                "pubshare_indices": pubshare_indices,
+                "pubnonce_indices": pubnonce_indices,
+                "secshare_index": my_id,
+                "secnonce_index": my_id,
+                "aggnonce": bytes_to_hex(aggnonce),
+                "msg": bytes_to_hex(msg),
+                "expected": bytes_to_hex(psig),
+            }
+        )
+
+    def _append_sign_error(
+        self,
+        my_id,
+        ids,
+        pubshare_indices,
+        secshare_idx,
+        secnonce_idx,
+        aggnonce,
+        msg,
+        error,
+        comment,
+    ):
+        pubshares = [self.inputs.pool_pubshares[i] for i in pubshare_indices]
+        secshare = self.inputs.pool_secshares[secshare_idx]
+        secnonce = bytearray(self.inputs.pool_secnonces[secnonce_idx])
+        signers = SignersContext(self.n, self.t, ids, pubshares, self.thresh_pk)
+        session = SessionContext(aggnonce, signers, [], [], msg)
+        expected = ValueError if error == "value" else InvalidContributionError
+        err = expect_exception(
+            lambda: sign(secnonce, secshare, my_id, session), expected
+        )
+        self.group["sign_error_tests"].append(
+            {
+                "comment": comment,
+                "my_id": my_id,
+                "ids": ids,
+                "pubshare_indices": pubshare_indices,
+                "secshare_index": secshare_idx,
+                "secnonce_index": secnonce_idx,
+                "aggnonce": bytes_to_hex(aggnonce),
+                "msg": bytes_to_hex(msg),
+                "error": err,
+            }
+        )
+
+    def _append_verify_error(
+        self,
+        ids,
+        pubshare_indices,
+        pubnonce_indices,
+        signer_index,
+        psig,
+        error,
+        comment,
+    ):
+        pubshares = [self.inputs.pool_pubshares[i] for i in pubshare_indices]
+        pubnonces = [self.inputs.pool_pubnonces[i] for i in pubnonce_indices]
+        msg = COMMON_MSGS[0]
+        signers = SignersContext(self.n, self.t, ids, pubshares, self.thresh_pk)
+        expected = ValueError if error == "value" else InvalidContributionError
+        err = expect_exception(
+            lambda: partial_sig_verify(
+                psig, pubnonces, signers, [], [], msg, signer_index
+            ),
+            expected,
+        )
+        self.group["verify_error_tests"].append(
+            {
+                "comment": comment,
+                "psig": bytes_to_hex(psig),
+                "ids": ids,
+                "pubshare_indices": pubshare_indices,
+                "pubnonce_indices": pubnonce_indices,
+                "signer_index": signer_index,
+                "msg": bytes_to_hex(msg),
+                "error": err,
+            }
+        )
+
+    def _append_verify_fail(
+        self, ids, pubshare_indices, pubnonce_indices, signer_index, psig, comment
+    ):
+        pubshares = [self.inputs.pool_pubshares[i] for i in pubshare_indices]
+        pubnonces = [self.inputs.pool_pubnonces[i] for i in pubnonce_indices]
+        msg = COMMON_MSGS[0]
+        signers = SignersContext(self.n, self.t, ids, pubshares, self.thresh_pk)
+        assert not partial_sig_verify(
+            psig, pubnonces, signers, [], [], msg, signer_index
+        )
+        self.group["verify_fail_tests"].append(
+            {
+                "comment": comment,
+                "psig": bytes_to_hex(psig),
+                "ids": ids,
+                "pubshare_indices": pubshare_indices,
+                "pubnonce_indices": pubnonce_indices,
+                "signer_index": signer_index,
+                "msg": bytes_to_hex(msg),
+            }
+        )
+
+    # --- Array A: valid_tests ---
+
+    def add_valid_tests(self):
+        t, n = self.t, self.n
+        # Minimum threshold subset.
+        self._append_valid(
+            0,
+            self.min_s,
+            self.min_s,
+            self.min_s,
+            self.aggnonce_min,
+            COMMON_MSGS[0],
+            "Minimum threshold subset of signers",
+        )
+        # Order-invariance (needs a set of size >= 2 to be meaningful).
+        if t >= 2:
+            rev = list(reversed(self.min_s))
+            self._append_valid(
+                0,
+                rev,
+                rev,
+                rev,
+                self._agg(rev),
+                COMMON_MSGS[0],
+                "Reordering the signer set leaves the partial signature unchanged, because the identifiers are sorted before they are bound into the binding value",
+            )
+        # A different threshold subset (needs t >= 2 and t < n, else the alt set
+        # collapses to the minimum set or is the only valid set).
+        if t >= 2 and t < n:
+            self._append_valid(
+                0,
+                self.alt,
+                self.alt,
+                self.alt,
+                self._agg(self.alt),
+                COMMON_MSGS[0],
+                "A different threshold subset gives a different partial signature, since the Lagrange coefficients depend on the signer set",
+            )
+        # All n signers, signed by a non-first member.
+        self._append_valid(
+            1,
+            self.full,
+            self.full,
+            self.full,
+            self._agg(self.full),
+            COMMON_MSGS[0],
+            "All signers participate, signed by a non-first member in the set",
+        )
+        # Aggregate nonce is the point at infinity. The inverse pubnonce cancels
+        # the first n-1 real pubnonces, so the aggregate over them is infinity.
+        inf_pubnonce_indices = list(range(n - 1)) + [self.inputs.INVERSE_PUBNONCE_IDX]
+        self._append_valid(
+            0,
+            self.full,
+            self.full,
+            inf_pubnonce_indices,
+            self._agg(inf_pubnonce_indices),
+            COMMON_MSGS[0],
+            "Aggregate nonce is the point at infinity, so the final nonce point falls back to the generator G",
+        )
+        # Message variations over the minimum set.
+        self._append_valid(
+            0,
+            self.min_s,
+            self.min_s,
+            self.min_s,
+            self.aggnonce_min,
+            COMMON_MSGS[1],
+            "Empty message",
+        )
+        self._append_valid(
+            0,
+            self.min_s,
+            self.min_s,
+            self.min_s,
+            self.aggnonce_min,
+            COMMON_MSGS[2],
+            "Non-standard message length (38 bytes)",
+        )
+
+    # --- Array B: sign_error_tests ---
+
+    def add_sign_error_tests(self):
+        t, n = self.t, self.n
+        # my_id is a valid participant absent from the set (needs t < n so a valid
+        # participant can sit outside the only valid set).
+        if t < n:
+            self._append_sign_error(
+                t,
+                self.min_s,
+                self.min_s,
+                0,
+                0,
+                self.aggnonce_min,
+                COMMON_MSGS[0],
+                "value",
+                "Signer's identifier is absent from the signer set",
+            )
+        # Duplicate id in the set (fixed [0, 1, 1], valid for every config).
+        self._append_sign_error(
+            0,
+            [0, 1, 1],
+            [0, 1, 1],
+            0,
+            0,
+            self.aggnonce_min,
+            COMMON_MSGS[0],
+            "value",
+            "Signer set contains a duplicate id",
+        )
+        # Signer loads the wrong share so its derived pubshare is absent (needs
+        # t >= 2 for distinct shares and t < n for a participant outside the set).
+        if t >= 2 and t < n:
+            self._append_sign_error(
+                1,
+                self.wrong,
+                self.wrong,
+                0,
+                0,
+                self._agg(self.wrong),
+                COMMON_MSGS[0],
+                "value",
+                "Signer's public share is not in the public share list",
+            )
+        # A listed public share is off-curve (at position 1, so min2 forces size 2).
+        pubshare_indices_11 = [
+            self.min2[0],
+            self.inputs.INVALID_PUBSHARE_IDX,
+        ] + self.min2[2:]
+        self._append_sign_error(
+            0,
+            self.min2,
+            pubshare_indices_11,
+            0,
+            0,
+            self._agg(self.min2),
+            COMMON_MSGS[0],
+            "value",
+            "A public share is not a valid point",
+        )
+        # A signer id equals n, outside the valid range. For t >= 2 the in-range
+        # member my_id=1 signs; at t=1 the lone id is out of range and the check fires
+        # first, so the self fields are inert.
+        if t >= 2:
+            ids_12 = [self.inputs.OUT_OF_RANGE_ID] + list(range(1, t))
+            self._append_sign_error(
+                1,
+                ids_12,
+                list(range(t)),
+                1,
+                1,
+                self.aggnonce_min,
+                COMMON_MSGS[0],
+                "value",
+                "A signer id is outside the valid range [0, n-1]",
+            )
+        else:
+            self._append_sign_error(
+                0,
+                [self.inputs.OUT_OF_RANGE_ID],
+                [0],
+                0,
+                0,
+                self._agg([0]),
+                COMMON_MSGS[0],
+                "value",
+                "A signer id is outside the valid range [0, n-1]",
+            )
+        # Public shares won't interpolate to the correct threshold key, since we're
+        # swapping the last two positions (needs t >= 2 for distinct shares).
+        if t >= 2:
+            self._append_sign_error(
+                0,
+                self.min_s,
+                swap_last_two(self.min_s),
+                0,
+                0,
+                self.aggnonce_min,
+                COMMON_MSGS[0],
+                "value",
+                "Signer set's public shares do not match the threshold public key",
+            )
+        # Invalid aggregate nonce literals.
+        self._append_sign_error(
+            0,
+            self.min_s,
+            self.min_s,
+            0,
+            0,
+            AGGNONCE_WRONG_TAG,
+            COMMON_MSGS[0],
+            "invalid_contrib",
+            "Aggregate nonce is invalid: first half has an unknown tag 0x04",
+        )
+        self._append_sign_error(
+            0,
+            self.min_s,
+            self.min_s,
+            0,
+            0,
+            AGGNONCE_BAD_XCOORD,
+            COMMON_MSGS[0],
+            "invalid_contrib",
+            "Aggregate nonce is invalid: second half is not a point on the curve",
+        )
+        self._append_sign_error(
+            0,
+            self.min_s,
+            self.min_s,
+            0,
+            0,
+            AGGNONCE_EXCEEDS_FIELD,
+            COMMON_MSGS[0],
+            "invalid_contrib",
+            "Aggregate nonce is invalid: second half's x-coordinate exceeds the field size",
+        )
+        # All-zero secret nonce (first scalar out of range).
+        self._append_sign_error(
+            0,
+            self.min_s,
+            self.min_s,
+            0,
+            self.inputs.SECNONCE_ZERO_IDX,
+            self.aggnonce_min,
+            COMMON_MSGS[0],
+            "value",
+            "Secret nonce's first half is out of range (all-zero nonce, which may indicate nonce reuse)",
+        )
+        # Secret nonce with a zero second scalar.
+        self._append_sign_error(
+            0,
+            self.min_s,
+            self.min_s,
+            0,
+            self.inputs.SECNONCE_ZERO_SECOND_IDX,
+            self.aggnonce_min,
+            COMMON_MSGS[0],
+            "value",
+            "Secret nonce's second half is out of range (zero)",
+        )
+        # Fewer signers than the threshold (empty set at t=1).
+        below = list(range(t - 1))
+        self._append_sign_error(
+            0,
+            below,
+            below,
+            0,
+            0,
+            self.aggnonce_min,
+            COMMON_MSGS[0],
+            "value",
+            "Fewer signers than the threshold t",
+        )
+        # Zero secret share.
+        self._append_sign_error(
+            0,
+            self.min_s,
+            self.min_s,
+            self.inputs.SECSHARE_ZERO_IDX,
+            0,
+            self.aggnonce_min,
+            COMMON_MSGS[0],
+            "value",
+            "Secret share is out of range (zero)",
+        )
+
+    # --- Array C: verify_fail_tests ---
+
+    def add_verify_fail_tests(self):
+        # Base partial signature: signer 0 over the size-at-least-2 baseline set.
+        secnonce = bytearray(self.inputs.pool_secnonces[0])
+        signers = SignersContext(
+            self.n,
+            self.t,
+            self.min2,
+            [self.inputs.pool_pubshares[i] for i in self.min2],
+            self.thresh_pk,
+        )
+        session = SessionContext(self._agg(self.min2), signers, [], [], COMMON_MSGS[0])
+        psig = sign(secnonce, self.inputs.pool_secshares[0], 0, session)
+        neg_psig = (-Scalar.from_bytes_checked(psig)).to_bytes()
+
+        self._append_verify_fail(
+            self.min2,
+            self.min2,
+            self.min2,
+            0,
+            neg_psig,
+            "Negated partial signature fails the verification equation",
+        )
+        self._append_verify_fail(
+            self.min2,
+            self.min2,
+            self.min2,
+            1,
+            psig,
+            "A valid partial signature checked against the wrong signer fails the verification equation",
+        )
+        self._append_verify_fail(
+            self.min2,
+            self.min2,
+            self.min2,
+            0,
+            bytes.fromhex(GROUP_ORDER_PSIG),
+            "Partial signature equals the group order, which is out of range",
+        )
+
+    # --- Array D: verify_error_tests ---
+
+    def add_verify_error_tests(self):
+        # Base partial signature: signer 0 over the minimum set.
+        secnonce = bytearray(self.inputs.pool_secnonces[0])
+        signers = SignersContext(
+            self.n,
+            self.t,
+            self.min_s,
+            [self.inputs.pool_pubshares[i] for i in self.min_s],
+            self.thresh_pk,
+        )
+        session = SessionContext(self.aggnonce_min, signers, [], [], COMMON_MSGS[0])
+        psig_min = sign(secnonce, self.inputs.pool_secshares[0], 0, session)
+
+        # Off-curve public nonce at position 0.
+        pubnonce_indices_24 = [self.inputs.INVALID_PUBNONCE_IDX] + self.min_s[1:]
+        self._append_verify_error(
+            self.min_s,
+            self.min_s,
+            pubnonce_indices_24,
+            0,
+            psig_min,
+            "invalid_contrib",
+            "Verification rejects an invalid public nonce, blaming the malicious signer",
+        )
+        # Off-curve public share at position 0.
+        pubshare_indices_25 = [self.inputs.INVALID_PUBSHARE_IDX] + self.min_s[1:]
+        self._append_verify_error(
+            self.min_s,
+            pubshare_indices_25,
+            self.min_s,
+            0,
+            psig_min,
+            "value",
+            "A public share is not a valid point",
+        )
+
+    def build(self):
+        self.add_valid_tests()
+        self.add_sign_error_tests()
+        self.add_verify_fail_tests()
+        self.add_verify_error_tests()
+        return self.group
+
 
 def generate_sign_verify_vectors():
-    n, t, thresh_pk, ids, secshares, pubshares = frost_keygen(SECKEY_2OF3)
-    xonly_thresh_pk = thresh_pk[1:]
-
-    secnonces, pubnonces = generate_all_nonces(
-        COMMON_RAND, secshares, pubshares, xonly_thresh_pk
-    )
-
-    # Build participant-aligned pools: first n values are for participants followed by invalids/specials.
-    # Referencing convention in the emitted cases: literal integers for
-    # participant indices (e.g. pubshare_indices=[0, 1]), named constants for
-    # the appended specials (e.g. INVALID_PUBSHARE_IDX, OUT_OF_RANGE_ID).
-    INVALID_PUBSHARE_IDX = n
-    INVALID_PUBNONCE_IDX = n
-    INVERSE_PUBNONCE_IDX = n + 1
-    SECSHARE_ZERO_IDX = n
-    SECNONCE_ZERO_IDX = n
-    SECNONCE_ZERO_SECOND_IDX = n + 1
-    OUT_OF_RANGE_ID = n
-
-    assert INVALID_PUBSHARE_IDX == 3
-    assert INVERSE_PUBNONCE_IDX == 4
-
-    pool_pubshares = pubshares + [INVALID_PUBSHARE]
-    pool_secshares = secshares + [b"\x00" * 32]
-
-    # compute inverse pubnonce: -(pubnonce[0] + pubnonce[1])
-    tmp = nonce_agg(pubnonces[:2])
-    R1 = GE.from_bytes_compressed_with_infinity(tmp[0:33])
-    R2 = GE.from_bytes_compressed_with_infinity(tmp[33:66])
-    inverse_pubnonce = (-R1).to_bytes_compressed_with_infinity() + (
-        -R2
-    ).to_bytes_compressed_with_infinity()
-    invalid_pubnonce = bytes.fromhex(
-        "0200000000000000000000000000000000000000000000000000000000000000090287BF891D2A6DEAEBADC909352AA9405D1428C15F4B75F04DAE642A95C2548480"
-    )
-    # Append order: invalid at index n (=3), inverse at index n+1 (=4)
-    pool_pubnonces = pubnonces + [invalid_pubnonce, inverse_pubnonce]
-
-    secnonce_all_zero = bytes.fromhex(
-        "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-    )
-    zero_second_secnonce = secnonces[0][0:32] + b"\x00" * 32
-    assert Scalar.from_bytes_nonzero_checked(zero_second_secnonce[0:32])
-    # Append order: all-zero at index n (=3), zero-second-half at index n+1 (=4)
-    pool_secnonces = secnonces + [secnonce_all_zero, zero_second_secnonce]
-
-    # Precompute inline aggnonces
-    aggnonce_01 = nonce_agg([pubnonces[0], pubnonces[1]])
-    aggnonce_02 = nonce_agg([pubnonces[0], pubnonces[2]])
-    aggnonce_012 = nonce_agg([pubnonces[0], pubnonces[1], pubnonces[2]])
-    # Infinity aggnonce: P0 + P1 + inverse_pubnonce cancels to infinity
-    aggnonce_inf = nonce_agg([pubnonces[0], pubnonces[1], inverse_pubnonce])
-    # Invalid aggnonce literals
-    aggnonce_wrong_tag = bytes.fromhex(
-        "048465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61037496A3CC86926D452CAFCFD55D25972CA1675D549310DE296BFF42F72EEEA8C9"
-    )
-    aggnonce_bad_xcoord = bytes.fromhex(
-        "028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61020000000000000000000000000000000000000000000000000000000000000009"
-    )
-    aggnonce_exceeds_field = bytes.fromhex(
-        "028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD6102FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30"
-    )
-
-    group = {
-        "tg_id": "2of3",
-        "t": t,
-        "n": n,
-        "thresh_pk": bytes_to_hex(thresh_pk),
-        "pubshares": bytes_list_to_hex(pool_pubshares),
-        "pubnonces": bytes_list_to_hex(pool_pubnonces),
-        "secshares": bytes_list_to_hex(pool_secshares),
-        "secnonces": bytes_list_to_hex(pool_secnonces),
-        "valid_tests": [],
-        "sign_error_tests": [],
-        "verify_fail_tests": [],
-        "verify_error_tests": [],
-    }
-    tc_id = 1
-
-    # --- Valid Test Cases ---
-    valid_cases = [
-        {
-            "my_id": 0,
-            "ids": [0, 1],
-            "pubshare_indices": [0, 1],
-            "pubnonce_indices": [0, 1],
-            "aggnonce": aggnonce_01,
-            "msg": COMMON_MSGS[0],
-            "secshare_index": 0,
-            "secnonce_index": 0,
-            "comment": "Minimum threshold subset of signers",
-        },
-        {
-            "my_id": 0,
-            "ids": [1, 0],
-            "pubshare_indices": [1, 0],
-            "pubnonce_indices": [1, 0],
-            "aggnonce": aggnonce_01,
-            "msg": COMMON_MSGS[0],
-            "secshare_index": 0,
-            "secnonce_index": 0,
-            "comment": "Reordering the signer set leaves the partial signature unchanged, because the identifiers are sorted before they are bound into the binding value",
-        },
-        {
-            "my_id": 0,
-            "ids": [0, 2],
-            "pubshare_indices": [0, 2],
-            "pubnonce_indices": [0, 2],
-            "aggnonce": aggnonce_02,
-            "msg": COMMON_MSGS[0],
-            "secshare_index": 0,
-            "secnonce_index": 0,
-            "comment": "A different threshold subset gives a different partial signature, since the Lagrange coefficients depend on the signer set",
-        },
-        {
-            "my_id": 1,
-            "ids": [0, 1, 2],
-            "pubshare_indices": [0, 1, 2],
-            "pubnonce_indices": [0, 1, 2],
-            "aggnonce": aggnonce_012,
-            "msg": COMMON_MSGS[0],
-            "secshare_index": 1,
-            "secnonce_index": 1,
-            "comment": "All n=3 signers participate, signed by a non-first member in the set",
-        },
-        {
-            "my_id": 0,
-            "ids": [0, 1, 2],
-            "pubshare_indices": [0, 1, 2],
-            "pubnonce_indices": [0, 1, INVERSE_PUBNONCE_IDX],
-            "aggnonce": aggnonce_inf,
-            "msg": COMMON_MSGS[0],
-            "secshare_index": 0,
-            "secnonce_index": 0,
-            "comment": "Aggregate nonce is the point at infinity, so the final nonce point falls back to the generator G",
-        },
-        {
-            "my_id": 0,
-            "ids": [0, 1],
-            "pubshare_indices": [0, 1],
-            "pubnonce_indices": [0, 1],
-            "aggnonce": aggnonce_01,
-            "msg": COMMON_MSGS[1],
-            "secshare_index": 0,
-            "secnonce_index": 0,
-            "comment": "Empty message",
-        },
-        {
-            "my_id": 0,
-            "ids": [0, 1],
-            "pubshare_indices": [0, 1],
-            "pubnonce_indices": [0, 1],
-            "aggnonce": aggnonce_01,
-            "msg": COMMON_MSGS[2],
-            "secshare_index": 0,
-            "secnonce_index": 0,
-            "comment": "Non-standard message length (38 bytes)",
-        },
-    ]
-    for case in valid_cases:
-        curr_ids = case["ids"]
-        curr_pubshares = [pool_pubshares[i] for i in case["pubshare_indices"]]
-        curr_pubnonces = [pool_pubnonces[i] for i in case["pubnonce_indices"]]
-        curr_aggnonce = case["aggnonce"]
-        curr_msg = case["msg"]
-        my_id = case["my_id"]
-        curr_secshare = pool_secshares[case["secshare_index"]]
-        curr_secnonce = bytearray(pool_secnonces[case["secnonce_index"]])
-
-        curr_signers = SignersContext(n, t, curr_ids, curr_pubshares, thresh_pk)
-        session_ctx = SessionContext(curr_aggnonce, curr_signers, [], [], curr_msg)
-        expected_psig = sign(curr_secnonce, curr_secshare, my_id, session_ctx)
-        signer_index = curr_ids.index(my_id)
-        assert partial_sig_verify(
-            expected_psig, curr_pubnonces, curr_signers, [], [], curr_msg, signer_index
-        )
-        group["valid_tests"].append(
-            {
-                "tc_id": tc_id,
-                "comment": case["comment"],
-                "my_id": my_id,
-                "ids": curr_ids,
-                "pubshare_indices": case["pubshare_indices"],
-                "pubnonce_indices": case["pubnonce_indices"],
-                "secshare_index": case["secshare_index"],
-                "secnonce_index": case["secnonce_index"],
-                "aggnonce": bytes_to_hex(curr_aggnonce),
-                "msg": bytes_to_hex(curr_msg),
-                "expected": bytes_to_hex(expected_psig),
-            }
-        )
-        tc_id += 1
-
-    # --- Sign Error Test Cases ---
-    sign_error_cases = [
-        {
-            # my_id=2 is outside ids=[0,1]. The signer presents participant 0's
-            # valid in-set material (secshare_index=0), since the id-membership
-            # check is only reached after the pubshare-membership check passes.
-            "my_id": 2,
-            "ids": [0, 1],
-            "pubshare_indices": [0, 1],
-            "aggnonce": aggnonce_01,
-            "msg": COMMON_MSGS[0],
-            "secshare_index": 0,
-            "secnonce_index": 0,
-            "error": "value",
-            "comment": "my_id is not in the signer set",
-        },
-        {
-            "my_id": 0,
-            "ids": [0, 1, 1],
-            "pubshare_indices": [0, 1, 1],
-            "aggnonce": aggnonce_01,
-            "msg": COMMON_MSGS[0],
-            "secshare_index": 0,
-            "secnonce_index": 0,
-            "error": "value",
-            "comment": "Signer set contains a duplicate id",
-        },
-        {
-            # The signer is set member my_id=1 but loads participant 0's secret
-            # share (secshare_index=0, the single bad field), so the derived public
-            # share is absent from the set {1,2}.
-            "my_id": 1,
-            "ids": [1, 2],
-            "pubshare_indices": [1, 2],
-            "aggnonce": aggnonce_01,
-            "msg": COMMON_MSGS[0],
-            "secshare_index": 0,
-            "secnonce_index": 0,
-            "error": "value",
-            "comment": "Signer's public share is not in the public share list",
-        },
-        {
-            "my_id": 0,
-            "ids": [0, 1],
-            "pubshare_indices": [0, INVALID_PUBSHARE_IDX],
-            "aggnonce": aggnonce_01,
-            "msg": COMMON_MSGS[0],
-            "secshare_index": 0,
-            "secnonce_index": 0,
-            "error": "value",
-            "comment": "A public share is not a valid point",
-        },
-        {
-            # ids=[3, 1] where 3 == n is out of range. The signer is the in-range
-            # member my_id=1, using participant 1's own secret share and nonce.
-            "my_id": 1,
-            "ids": [OUT_OF_RANGE_ID, 1],
-            "pubshare_indices": [0, 1],
-            "aggnonce": aggnonce_01,
-            "msg": COMMON_MSGS[0],
-            "secshare_index": 1,
-            "secnonce_index": 1,
-            "error": "value",
-            "comment": "A signer id is outside the valid range [0, n-1]",
-        },
-        {
-            "my_id": 0,
-            "ids": [0, 1],
-            "pubshare_indices": [0, 2],
-            "aggnonce": aggnonce_01,
-            "msg": COMMON_MSGS[0],
-            "secshare_index": 0,
-            "secnonce_index": 0,
-            "error": "value",
-            "comment": "Signer set's public shares do not match the threshold public key",
-        },
-        {
-            "my_id": 0,
-            "ids": [0, 1],
-            "pubshare_indices": [0, 1],
-            "aggnonce": aggnonce_wrong_tag,
-            "msg": COMMON_MSGS[0],
-            "secshare_index": 0,
-            "secnonce_index": 0,
-            "error": "invalid_contrib",
-            "comment": "Aggregate nonce is invalid: first half has an unknown tag 0x04",
-        },
-        {
-            "my_id": 0,
-            "ids": [0, 1],
-            "pubshare_indices": [0, 1],
-            "aggnonce": aggnonce_bad_xcoord,
-            "msg": COMMON_MSGS[0],
-            "secshare_index": 0,
-            "secnonce_index": 0,
-            "error": "invalid_contrib",
-            "comment": "Aggregate nonce is invalid: second half is not a point on the curve",
-        },
-        {
-            "my_id": 0,
-            "ids": [0, 1],
-            "pubshare_indices": [0, 1],
-            "aggnonce": aggnonce_exceeds_field,
-            "msg": COMMON_MSGS[0],
-            "secshare_index": 0,
-            "secnonce_index": 0,
-            "error": "invalid_contrib",
-            "comment": "Aggregate nonce is invalid: second half's x-coordinate exceeds the field size",
-        },
-        {
-            "my_id": 0,
-            "ids": [0, 1],
-            "pubshare_indices": [0, 1],
-            "aggnonce": aggnonce_01,
-            "msg": COMMON_MSGS[0],
-            "secshare_index": 0,
-            "secnonce_index": SECNONCE_ZERO_IDX,
-            "error": "value",
-            "comment": "Secret nonce's first half is out of range (all-zero nonce, which may indicate nonce reuse)",
-        },
-        {
-            "my_id": 0,
-            "ids": [0, 1],
-            "pubshare_indices": [0, 1],
-            "aggnonce": aggnonce_01,
-            "msg": COMMON_MSGS[0],
-            "secshare_index": 0,
-            "secnonce_index": SECNONCE_ZERO_SECOND_IDX,
-            "error": "value",
-            "comment": "Secret nonce's second half is out of range (zero)",
-        },
-        {
-            # aggnonce_01 doesn't match the single-signer set, but it's never
-            # inspected: SignersContext rejects the sub-threshold set first.
-            "my_id": 0,
-            "ids": [0],
-            "pubshare_indices": [0],
-            "aggnonce": aggnonce_01,
-            "msg": COMMON_MSGS[0],
-            "secshare_index": 0,
-            "secnonce_index": 0,
-            "error": "value",
-            "comment": "Fewer signers than the threshold t",
-        },
-        {
-            "my_id": 0,
-            "ids": [0, 1],
-            "pubshare_indices": [0, 1],
-            "aggnonce": aggnonce_01,
-            "msg": COMMON_MSGS[0],
-            "secshare_index": SECSHARE_ZERO_IDX,
-            "secnonce_index": 0,
-            "error": "value",
-            "comment": "Secret share is out of range (zero)",
-        },
-    ]
-    for case in sign_error_cases:
-        curr_ids = case["ids"]
-        curr_pubshares = [pool_pubshares[i] for i in case["pubshare_indices"]]
-        curr_aggnonce = case["aggnonce"]
-        curr_msg = case["msg"]
-        my_id = case["my_id"]
-        curr_secnonce = bytearray(pool_secnonces[case["secnonce_index"]])
-        curr_secshare = pool_secshares[case["secshare_index"]]
-
-        curr_signers = SignersContext(n, t, curr_ids, curr_pubshares, thresh_pk)
-        session_ctx = SessionContext(curr_aggnonce, curr_signers, [], [], curr_msg)
-        expected_error = (
-            ValueError if case["error"] == "value" else InvalidContributionError
-        )
-        error = expect_exception(
-            lambda: sign(curr_secnonce, curr_secshare, my_id, session_ctx),
-            expected_error,
-        )
-        group["sign_error_tests"].append(
-            {
-                "tc_id": tc_id,
-                "comment": case["comment"],
-                "my_id": my_id,
-                "ids": curr_ids,
-                "pubshare_indices": case["pubshare_indices"],
-                "secshare_index": case["secshare_index"],
-                "secnonce_index": case["secnonce_index"],
-                "aggnonce": bytes_to_hex(curr_aggnonce),
-                "msg": bytes_to_hex(curr_msg),
-                "error": error,
-            }
-        )
-        tc_id += 1
-
-    # --- Verify Fail and Verify Error base: sign as P0 over [0,1], agg(0,1), msg0 ---
-    vf_ids = [0, 1]
-    vf_pubshare_indices = [0, 1]
-    vf_pubnonce_indices = [0, 1]
-    vf_msg = COMMON_MSGS[0]
-    vf_aggnonce = aggnonce_01
-    vf_my_id = 0
-
-    vf_pubshares = [pool_pubshares[i] for i in vf_pubshare_indices]
-    vf_signers = SignersContext(n, t, vf_ids, vf_pubshares, thresh_pk)
-    vf_session = SessionContext(vf_aggnonce, vf_signers, [], [], vf_msg)
-    vf_secnonce = bytearray(pool_secnonces[0])
-    psig = sign(vf_secnonce, pool_secshares[0], vf_my_id, vf_session)
-
-    # --- Verify Fail Test Cases ---
-    psig_scalar = Scalar.from_bytes_checked(psig)
-    neg_psig = (-psig_scalar).to_bytes()
-
-    group["verify_fail_tests"].append(
-        {
-            "tc_id": tc_id,
-            "comment": "Negated partial signature fails the verification equation",
-            "psig": bytes_to_hex(neg_psig),
-            "ids": vf_ids,
-            "pubshare_indices": vf_pubshare_indices,
-            "pubnonce_indices": vf_pubnonce_indices,
-            "signer_index": 0,
-            "msg": bytes_to_hex(vf_msg),
-        }
-    )
-    tc_id += 1
-
-    group["verify_fail_tests"].append(
-        {
-            "tc_id": tc_id,
-            "comment": "A valid partial signature checked against the wrong signer fails the verification equation",
-            "psig": bytes_to_hex(psig),
-            "ids": vf_ids,
-            "pubshare_indices": vf_pubshare_indices,
-            "pubnonce_indices": vf_pubnonce_indices,
-            "signer_index": 1,
-            "msg": bytes_to_hex(vf_msg),
-        }
-    )
-    tc_id += 1
-
-    group["verify_fail_tests"].append(
-        {
-            "tc_id": tc_id,
-            "comment": "Partial signature equals the group order, which is out of range",
-            "psig": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
-            "ids": vf_ids,
-            "pubshare_indices": vf_pubshare_indices,
-            "pubnonce_indices": vf_pubnonce_indices,
-            "signer_index": 0,
-            "msg": bytes_to_hex(vf_msg),
-        }
-    )
-    tc_id += 1
-
-    # --- Verify Error Test Cases ---
-    verify_error_cases = [
-        {
-            "ids": [0, 1],
-            "pubshare_indices": [0, 1],
-            "pubnonce_indices": [INVALID_PUBNONCE_IDX, 1],
-            "msg": COMMON_MSGS[0],
-            "signer_index": 0,
-            "error": "invalid_contrib",
-            "comment": "Verification rejects an invalid public nonce, blaming the malicious signer",
-        },
-        {
-            "ids": [0, 1],
-            "pubshare_indices": [INVALID_PUBSHARE_IDX, 1],
-            "pubnonce_indices": [0, 1],
-            "msg": COMMON_MSGS[0],
-            "signer_index": 0,
-            "error": "value",
-            "comment": "A public share is not a valid point",
-        },
-    ]
-    for case in verify_error_cases:
-        curr_ids = case["ids"]
-        curr_pubshares = [pool_pubshares[i] for i in case["pubshare_indices"]]
-        curr_pubnonces = [pool_pubnonces[i] for i in case["pubnonce_indices"]]
-        curr_msg = case["msg"]
-        signer_index = case["signer_index"]
-        curr_signers = SignersContext(n, t, curr_ids, curr_pubshares, thresh_pk)
-        expected_error = (
-            ValueError if case["error"] == "value" else InvalidContributionError
-        )
-        error = expect_exception(
-            # reuse the valid psig generated for verify_fail cases
-            lambda: partial_sig_verify(
-                psig, curr_pubnonces, curr_signers, [], [], curr_msg, signer_index
-            ),
-            expected_error,
-        )
-        group["verify_error_tests"].append(
-            {
-                "tc_id": tc_id,
-                "comment": case["comment"],
-                "psig": bytes_to_hex(psig),
-                "ids": curr_ids,
-                "pubshare_indices": case["pubshare_indices"],
-                "pubnonce_indices": case["pubnonce_indices"],
-                "signer_index": signer_index,
-                "msg": bytes_to_hex(curr_msg),
-                "error": error,
-            }
-        )
-        tc_id += 1
-
-    vectors = {"test_groups": [group]}
-    write_test_vectors("sign_verify_vectors.json", vectors)
+    groups = [SignVerifyGroupBuilder(cfg).build() for cfg in CONFIGS]
+    assign_tc_ids(groups)
+    write_test_vectors("sign_verify_vectors.json", {"test_groups": groups})

--- a/python/generators/sign_verify.py
+++ b/python/generators/sign_verify.py
@@ -113,7 +113,7 @@ def generate_sign_verify_vectors():
             "msg": COMMON_MSGS[0],
             "secshare_index": 0,
             "secnonce_index": 0,
-            "comment": "Minimum threshold subset of signers (t=2 of n=3)",
+            "comment": "Minimum threshold subset of signers",
         },
         {
             "my_id": 0,
@@ -475,7 +475,7 @@ def generate_sign_verify_vectors():
             "msg": COMMON_MSGS[0],
             "signer_index": 0,
             "error": "invalid_contrib",
-            "comment": "Verification rejects an invalid public nonce, attributing the contribution fault to the offending signer",
+            "comment": "Verification rejects an invalid public nonce, blaming the malicious signer",
         },
         {
             "ids": [0, 1],

--- a/python/generators/sign_verify.py
+++ b/python/generators/sign_verify.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from frost_ref import (
     InvalidContributionError,
     SessionContext,
@@ -67,12 +69,19 @@ class SignVerifyGroupBuilder:
         self.group["verify_fail_tests"] = []
         self.group["verify_error_tests"] = []
 
-    def _agg(self, pubnonce_indices):
+    def _agg(self, pubnonce_indices: List[int]) -> bytes:
         return nonce_agg([self.inputs.pool_pubnonces[i] for i in pubnonce_indices])
 
     def _append_valid(
-        self, my_id, ids, pubshare_indices, pubnonce_indices, aggnonce, msg, comment
-    ):
+        self,
+        my_id: int,
+        ids: List[int],
+        pubshare_indices: List[int],
+        pubnonce_indices: List[int],
+        aggnonce: bytes,
+        msg: bytes,
+        comment: str,
+    ) -> None:
         pubshares = [self.inputs.pool_pubshares[i] for i in pubshare_indices]
         pubnonces = [self.inputs.pool_pubnonces[i] for i in pubnonce_indices]
         secnonce = bytearray(self.inputs.pool_secnonces[my_id])
@@ -99,24 +108,24 @@ class SignVerifyGroupBuilder:
 
     def _append_sign_error(
         self,
-        my_id,
-        ids,
-        pubshare_indices,
-        secshare_idx,
-        secnonce_idx,
-        aggnonce,
-        msg,
-        error,
-        comment,
-    ):
+        my_id: int,
+        ids: List[int],
+        pubshare_indices: List[int],
+        secshare_idx: int,
+        secnonce_idx: int,
+        aggnonce: bytes,
+        msg: bytes,
+        error: str,
+        comment: str,
+    ) -> None:
         pubshares = [self.inputs.pool_pubshares[i] for i in pubshare_indices]
         secshare = self.inputs.pool_secshares[secshare_idx]
         secnonce = bytearray(self.inputs.pool_secnonces[secnonce_idx])
         signers = SignersContext(self.n, self.t, ids, pubshares, self.thresh_pk)
         session = SessionContext(aggnonce, signers, [], [], msg)
-        expected = ValueError if error == "value" else InvalidContributionError
+        expected_exc = ValueError if error == "value" else InvalidContributionError
         err = expect_exception(
-            lambda: sign(secnonce, secshare, my_id, session), expected
+            lambda: sign(secnonce, secshare, my_id, session), expected_exc
         )
         self.group["sign_error_tests"].append(
             {
@@ -134,24 +143,24 @@ class SignVerifyGroupBuilder:
 
     def _append_verify_error(
         self,
-        ids,
-        pubshare_indices,
-        pubnonce_indices,
-        signer_index,
-        psig,
-        error,
-        comment,
-    ):
+        ids: List[int],
+        pubshare_indices: List[int],
+        pubnonce_indices: List[int],
+        signer_index: int,
+        psig: bytes,
+        error: str,
+        comment: str,
+    ) -> None:
         pubshares = [self.inputs.pool_pubshares[i] for i in pubshare_indices]
         pubnonces = [self.inputs.pool_pubnonces[i] for i in pubnonce_indices]
         msg = COMMON_MSGS[0]
         signers = SignersContext(self.n, self.t, ids, pubshares, self.thresh_pk)
-        expected = ValueError if error == "value" else InvalidContributionError
+        expected_exc = ValueError if error == "value" else InvalidContributionError
         err = expect_exception(
             lambda: partial_sig_verify(
                 psig, pubnonces, signers, [], [], msg, signer_index
             ),
-            expected,
+            expected_exc,
         )
         self.group["verify_error_tests"].append(
             {
@@ -167,8 +176,14 @@ class SignVerifyGroupBuilder:
         )
 
     def _append_verify_fail(
-        self, ids, pubshare_indices, pubnonce_indices, signer_index, psig, comment
-    ):
+        self,
+        ids: List[int],
+        pubshare_indices: List[int],
+        pubnonce_indices: List[int],
+        signer_index: int,
+        psig: bytes,
+        comment: str,
+    ) -> None:
         pubshares = [self.inputs.pool_pubshares[i] for i in pubshare_indices]
         pubnonces = [self.inputs.pool_pubnonces[i] for i in pubnonce_indices]
         msg = COMMON_MSGS[0]
@@ -190,7 +205,7 @@ class SignVerifyGroupBuilder:
 
     # --- Array A: valid_tests ---
 
-    def add_valid_tests(self):
+    def add_valid_tests(self) -> None:
         t, n = self.t, self.n
         # Minimum threshold subset.
         self._append_valid(
@@ -234,7 +249,7 @@ class SignVerifyGroupBuilder:
             self.full,
             self._agg(self.full),
             COMMON_MSGS[0],
-            "All signers participate, signed by a non-first member in the set",
+            "All signers participate, signed by a non-first member of the signer set",
         )
         # Aggregate nonce is the point at infinity. The inverse pubnonce cancels
         # the first n-1 real pubnonces, so the aggregate over them is infinity.
@@ -270,7 +285,7 @@ class SignVerifyGroupBuilder:
 
     # --- Array B: sign_error_tests ---
 
-    def add_sign_error_tests(self):
+    def add_sign_error_tests(self) -> None:
         t, n = self.t, self.n
         # my_id is a valid participant absent from the set (needs t < n so a valid
         # participant can sit outside the only valid set).
@@ -301,6 +316,7 @@ class SignVerifyGroupBuilder:
         # Signer loads the wrong share so its derived pubshare is absent (needs
         # t >= 2 for distinct shares and t < n for a participant outside the set).
         if t >= 2 and t < n:
+            assert self.wrong is not None
             self._append_sign_error(
                 1,
                 self.wrong,
@@ -313,14 +329,14 @@ class SignVerifyGroupBuilder:
                 "Signer's public share is not in the public share list",
             )
         # A listed public share is off-curve (at position 1, so min2 forces size 2).
-        pubshare_indices_11 = [
+        pubshare_indices_offcurve = [
             self.min2[0],
             self.inputs.INVALID_PUBSHARE_IDX,
         ] + self.min2[2:]
         self._append_sign_error(
             0,
             self.min2,
-            pubshare_indices_11,
+            pubshare_indices_offcurve,
             0,
             0,
             self._agg(self.min2),
@@ -328,14 +344,14 @@ class SignVerifyGroupBuilder:
             "value",
             "A public share is not a valid point",
         )
-        # A signer id equals n, outside the valid range. For t >= 2 the in-range
-        # member my_id=1 signs; at t=1 the lone id is out of range and the check fires
+        # A signer id equals n, outside the valid range. For t >= 2 an in-range
+        # member signs. At t=1 the lone id is out of range and the check fires
         # first, so the self fields are inert.
         if t >= 2:
-            ids_12 = [self.inputs.OUT_OF_RANGE_ID] + list(range(1, t))
+            ids_out_of_range = [self.inputs.OUT_OF_RANGE_ID] + list(range(1, t))
             self._append_sign_error(
                 1,
-                ids_12,
+                ids_out_of_range,
                 list(range(t)),
                 1,
                 1,
@@ -456,7 +472,7 @@ class SignVerifyGroupBuilder:
 
     # --- Array C: verify_fail_tests ---
 
-    def add_verify_fail_tests(self):
+    def add_verify_fail_tests(self) -> None:
         # Base partial signature: signer 0 over the size-at-least-2 baseline set.
         secnonce = bytearray(self.inputs.pool_secnonces[0])
         signers = SignersContext(
@@ -497,7 +513,7 @@ class SignVerifyGroupBuilder:
 
     # --- Array D: verify_error_tests ---
 
-    def add_verify_error_tests(self):
+    def add_verify_error_tests(self) -> None:
         # Base partial signature: signer 0 over the minimum set.
         secnonce = bytearray(self.inputs.pool_secnonces[0])
         signers = SignersContext(
@@ -511,21 +527,21 @@ class SignVerifyGroupBuilder:
         psig_min = sign(secnonce, self.inputs.pool_secshares[0], 0, session)
 
         # Off-curve public nonce at position 0.
-        pubnonce_indices_24 = [self.inputs.INVALID_PUBNONCE_IDX] + self.min_s[1:]
+        pubnonce_indices_offcurve = [self.inputs.INVALID_PUBNONCE_IDX] + self.min_s[1:]
         self._append_verify_error(
             self.min_s,
             self.min_s,
-            pubnonce_indices_24,
+            pubnonce_indices_offcurve,
             0,
             psig_min,
             "invalid_contrib",
             "Verification rejects an invalid public nonce, blaming the malicious signer",
         )
         # Off-curve public share at position 0.
-        pubshare_indices_25 = [self.inputs.INVALID_PUBSHARE_IDX] + self.min_s[1:]
+        pubshare_indices_offcurve = [self.inputs.INVALID_PUBSHARE_IDX] + self.min_s[1:]
         self._append_verify_error(
             self.min_s,
-            pubshare_indices_25,
+            pubshare_indices_offcurve,
             self.min_s,
             0,
             psig_min,
@@ -533,7 +549,7 @@ class SignVerifyGroupBuilder:
             "A public share is not a valid point",
         )
 
-    def build(self):
+    def build(self) -> dict:
         self.add_valid_tests()
         self.add_sign_error_tests()
         self.add_verify_fail_tests()
@@ -541,7 +557,7 @@ class SignVerifyGroupBuilder:
         return self.group
 
 
-def generate_sign_verify_vectors():
+def generate_sign_verify_vectors() -> None:
     groups = [SignVerifyGroupBuilder(cfg).build() for cfg in CONFIGS]
     assign_tc_ids(groups)
     write_test_vectors("sign_verify_vectors.json", {"test_groups": groups})

--- a/python/generators/tweak.py
+++ b/python/generators/tweak.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from frost_ref import (
     SessionContext,
     SignersContext,
@@ -37,6 +39,7 @@ class TweakGroupBuilder:
 
         self.min_s = get_subset(cfg, "min")
         self.full = get_subset(cfg, "full")
+        self.aggnonce_min = self._agg(self.min_s)
 
         # Build the tweaks pool: self.inputs.tweaks_pool has 6 entries (indices 0-5).
         # Append INVALID_33_BYTE_TWEAK at index 6.
@@ -45,10 +48,11 @@ class TweakGroupBuilder:
 
         self.group = {}
         set_group_config(self.group, cfg, self.inputs)
-        # Serialize the real arrays, not the *_pool versions: tweak error cases
-        # only fault the tweak value, so we only the tweaks pool which contain
-        # invalid entries. Invalid pubshares, secshares, and nonces are tested in
-        # sign_vectors.json, not here. So, we don't need their *_pool versions.
+        # Tweak error cases fault only the tweak value, so the group serializes the
+        # real (non-pool) pubshares, pubnonces, secshares, and secnonces. The tweaks
+        # array is the extended pool with the invalid 33-byte entry appended. Invalid
+        # pubshare, nonce, and secret-share faults are covered in
+        # sign_verify_vectors.json, not here.
         self.group["pubshares"] = bytes_list_to_hex(self.inputs.pubshares)
         self.group["pubnonces"] = bytes_list_to_hex(self.inputs.pubnonces)
         self.group["secshares"] = bytes_list_to_hex(self.inputs.secshares)
@@ -57,21 +61,21 @@ class TweakGroupBuilder:
         self.group["valid_tests"] = []
         self.group["error_tests"] = []
 
-    def _agg(self, pubnonce_indices):
+    def _agg(self, pubnonce_indices: List[int]) -> bytes:
         return nonce_agg([self.inputs.pubnonces[i] for i in pubnonce_indices])
 
     def _append_valid(
         self,
-        my_id,
-        ids,
-        pubshare_indices,
-        pubnonce_indices,
-        aggnonce,
-        msg,
-        tweak_indices,
-        is_xonly,
-        comment,
-    ):
+        my_id: int,
+        ids: List[int],
+        pubshare_indices: List[int],
+        pubnonce_indices: List[int],
+        aggnonce: bytes,
+        msg: bytes,
+        tweak_indices: List[int],
+        is_xonly: List[bool],
+        comment: str,
+    ) -> None:
         pubshares = [self.inputs.pubshares[i] for i in pubshare_indices]
         tweaks = [self.tweaks_pool[i] for i in tweak_indices]
         secnonce = bytearray(self.inputs.secnonces[my_id])
@@ -106,24 +110,24 @@ class TweakGroupBuilder:
 
     def _append_error(
         self,
-        my_id,
-        ids,
-        pubshare_indices,
-        secshare_index,
-        secnonce_index,
-        aggnonce,
-        msg,
-        tweak_indices,
-        is_xonly,
-        comment,
-    ):
+        my_id: int,
+        ids: List[int],
+        pubshare_indices: List[int],
+        secshare_index: int,
+        secnonce_index: int,
+        aggnonce: bytes,
+        msg: bytes,
+        tweak_indices: List[int],
+        is_xonly: List[bool],
+        comment: str,
+    ) -> None:
         pubshares = [self.inputs.pubshares[i] for i in pubshare_indices]
         tweaks = [self.tweaks_pool[i] for i in tweak_indices]
         secnonce = bytearray(self.inputs.secnonces[secnonce_index])
         secshare = self.inputs.secshares[secshare_index]
         signers = SignersContext(self.n, self.t, ids, pubshares, self.thresh_pk)
         session = SessionContext(aggnonce, signers, tweaks, is_xonly, msg)
-        error = expect_exception(
+        err = expect_exception(
             lambda: sign(secnonce, secshare, my_id, session), ValueError
         )
         self.group["error_tests"].append(
@@ -138,15 +142,14 @@ class TweakGroupBuilder:
                 "msg": bytes_to_hex(msg),
                 "tweak_indices": tweak_indices,
                 "is_xonly": is_xonly,
-                "error": error,
+                "error": err,
             }
         )
 
     # --- Array A: valid_tests ---
 
-    def add_valid_tests(self):
+    def add_valid_tests(self) -> None:
         msg = COMMON_MSGS[0]
-        aggnonce_min = self._agg(self.min_s)
         aggnonce_full = self._agg(self.full)
 
         # No tweaks applied
@@ -155,7 +158,7 @@ class TweakGroupBuilder:
             self.min_s,
             self.min_s,
             self.min_s,
-            aggnonce_min,
+            self.aggnonce_min,
             msg,
             [],
             [],
@@ -167,7 +170,7 @@ class TweakGroupBuilder:
             self.min_s,
             self.min_s,
             self.min_s,
-            aggnonce_min,
+            self.aggnonce_min,
             msg,
             [0],
             [True],
@@ -179,7 +182,7 @@ class TweakGroupBuilder:
             self.min_s,
             self.min_s,
             self.min_s,
-            aggnonce_min,
+            self.aggnonce_min,
             msg,
             [0],
             [False],
@@ -191,7 +194,7 @@ class TweakGroupBuilder:
             self.min_s,
             self.min_s,
             self.min_s,
-            aggnonce_min,
+            self.aggnonce_min,
             msg,
             [0, 1],
             [False, True],
@@ -203,7 +206,7 @@ class TweakGroupBuilder:
             self.min_s,
             self.min_s,
             self.min_s,
-            aggnonce_min,
+            self.aggnonce_min,
             msg,
             [0, 1, 2, 3],
             [True, False, True, False],
@@ -215,7 +218,7 @@ class TweakGroupBuilder:
             self.min_s,
             self.min_s,
             self.min_s,
-            aggnonce_min,
+            self.aggnonce_min,
             msg,
             [0, 1, 2, 3],
             [False, False, True, True],
@@ -236,9 +239,8 @@ class TweakGroupBuilder:
 
     # --- Array B: error_tests ---
 
-    def add_error_tests(self):
+    def add_error_tests(self) -> None:
         msg = COMMON_MSGS[0]
-        aggnonce_min = self._agg(self.min_s)
         my_id = 0
 
         # Tweak exceeds the group order
@@ -248,7 +250,7 @@ class TweakGroupBuilder:
             self.min_s,
             0,
             0,
-            aggnonce_min,
+            self.aggnonce_min,
             msg,
             [self.inputs.OUT_OF_RANGE_TWEAK_IDX],
             [False],
@@ -261,7 +263,7 @@ class TweakGroupBuilder:
             self.min_s,
             0,
             0,
-            aggnonce_min,
+            self.aggnonce_min,
             msg,
             [self.inputs.INFINITY_TWEAK_IDX],
             [False],
@@ -274,7 +276,7 @@ class TweakGroupBuilder:
             self.min_s,
             0,
             0,
-            aggnonce_min,
+            self.aggnonce_min,
             msg,
             [0],
             [],
@@ -287,20 +289,20 @@ class TweakGroupBuilder:
             self.min_s,
             0,
             0,
-            aggnonce_min,
+            self.aggnonce_min,
             msg,
             [self.INVALID_33_BYTE_TWEAK_IDX],
             [False],
             "Tweak is not a 32-byte array",
         )
 
-    def build(self):
+    def build(self) -> dict:
         self.add_valid_tests()
         self.add_error_tests()
         return self.group
 
 
-def generate_tweak_vectors():
+def generate_tweak_vectors() -> None:
     groups = [TweakGroupBuilder(cfg).build() for cfg in CONFIGS]
     assign_tc_ids(groups)
     write_test_vectors("tweak_vectors.json", {"test_groups": groups})

--- a/python/generators/tweak.py
+++ b/python/generators/tweak.py
@@ -1,213 +1,306 @@
-from frost_ref import SessionContext, SignersContext, nonce_agg, sign
-from secp256k1lab.secp256k1 import G, GE
+from frost_ref import (
+    SessionContext,
+    SignersContext,
+    nonce_agg,
+    partial_sig_verify,
+    sign,
+)
 
 from generators.common import (
     COMMON_MSGS,
-    COMMON_RAND,
-    COMMON_TWEAKS,
-    INVALID_PUBSHARE,
-    OUT_OF_RANGE_TWEAK,
-    SECKEY_2OF3,
+    CONFIGS,
+    SharedGroupInputs,
+    assign_tc_ids,
     bytes_list_to_hex,
     bytes_to_hex,
     expect_exception,
-    frost_keygen,
-    generate_all_nonces,
-    reconstruct_thresh_sk,
+    get_subset,
+    set_group_config,
     write_test_vectors,
 )
 
-# an invalid 33-byte tweak value
+# an invalid 33-byte tweak value, kept local to this generator rather than in common.py
 INVALID_33_BYTE_TWEAK = bytes.fromhex(
     "E8F791FF9225A2AF0102AFFF4A9A723D9612A682A25EBE79802B263CDFCD83BBFF"
 )
 
 
-def generate_tweak_vectors():
-    n, t, thresh_pk, ids, secshares, pubshares = frost_keygen(SECKEY_2OF3)
-    xonly_thresh_pk = thresh_pk[1:]
+class TweakGroupBuilder:
+    """Builds one (t, n) test group for tweak_vectors.json. Shared inputs and
+    subsets live on self. Each add_* method appends its category to self.group."""
 
-    pubshares_with_invalid = pubshares + [INVALID_PUBSHARE]
+    def __init__(self, cfg):
+        self.inputs = SharedGroupInputs(cfg)
+        self.t = self.inputs.t
+        self.n = self.inputs.n
+        self.thresh_pk = self.inputs.thresh_pk
 
-    secnonces, pubnonces = generate_all_nonces(
-        COMMON_RAND, secshares, pubshares, xonly_thresh_pk
-    )
+        self.min_s = get_subset(cfg, "min")
+        self.full = get_subset(cfg, "full")
 
-    # Precompute inline aggnonces
-    aggnonce_01 = nonce_agg([pubnonces[0], pubnonces[1]])
-    aggnonce_012 = nonce_agg([pubnonces[0], pubnonces[1], pubnonces[2]])
+        # Build the tweaks pool: self.inputs.tweaks_pool has 6 entries (indices 0-5).
+        # Append INVALID_33_BYTE_TWEAK at index 6.
+        self.tweaks_pool = list(self.inputs.tweaks_pool) + [INVALID_33_BYTE_TWEAK]
+        self.INVALID_33_BYTE_TWEAK_IDX = len(self.inputs.tweaks_pool)
 
-    # Compute a plain tweak that drives Q + twk*G to the point at infinity: twk = -thresh_sk.
-    infinity_tweak_scalar = -reconstruct_thresh_sk([0, 1], secshares[:2])
-    assert (GE.from_bytes_compressed(thresh_pk) + infinity_tweak_scalar * G).infinity
+        self.group = {}
+        set_group_config(self.group, cfg, self.inputs)
+        # Serialize the real arrays, not the *_pool versions: tweak error cases
+        # only fault the tweak value, so we only the tweaks pool which contain
+        # invalid entries. Invalid pubshares, secshares, and nonces are tested in
+        # sign_vectors.json, not here. So, we don't need their *_pool versions.
+        self.group["pubshares"] = bytes_list_to_hex(self.inputs.pubshares)
+        self.group["pubnonces"] = bytes_list_to_hex(self.inputs.pubnonces)
+        self.group["secshares"] = bytes_list_to_hex(self.inputs.secshares)
+        self.group["secnonces"] = bytes_list_to_hex(self.inputs.secnonces)
+        self.group["tweaks"] = bytes_list_to_hex(self.tweaks_pool)
+        self.group["valid_tests"] = []
+        self.group["error_tests"] = []
 
-    # 7 entries: indices 0-3 valid (COMMON_TWEAKS), index 4 out-of-range,
-    # index 5 drives the tweaked threshold public key to infinity,
-    # index 6 is not a 32-byte array
-    OUT_OF_RANGE_TWEAK_IDX = len(COMMON_TWEAKS)
-    INFINITY_TWEAK_IDX = len(COMMON_TWEAKS) + 1
-    INVALID_33_BYTE_TWEAK_IDX = len(COMMON_TWEAKS) + 2
-    tweaks_pool = COMMON_TWEAKS + [
-        OUT_OF_RANGE_TWEAK,
-        infinity_tweak_scalar.to_bytes(),
-        INVALID_33_BYTE_TWEAK,
-    ]
+    def _agg(self, pubnonce_indices):
+        return nonce_agg([self.inputs.pubnonces[i] for i in pubnonce_indices])
 
-    group = {
-        "tg_id": "2of3",
-        "t": t,
-        "n": n,
-        "thresh_pk": bytes_to_hex(thresh_pk),
-        "pubshares": bytes_list_to_hex(pubshares_with_invalid),
-        "pubnonces": bytes_list_to_hex(pubnonces),
-        "secshares": bytes_list_to_hex(secshares),
-        "secnonces": bytes_list_to_hex(secnonces),
-        "tweaks": bytes_list_to_hex(tweaks_pool),
-        "valid_tests": [],
-        "error_tests": [],
-    }
-    tc_id = 1
-
-    # --- Valid Test Cases ---
-    valid_cases = [
-        {
-            "tweaks_indices": [],
-            "is_xonly": [],
-            "aggnonce": bytes_to_hex(aggnonce_01),
-            "comment": "No tweaks applied",
-        },
-        {
-            "tweaks_indices": [0],
-            "is_xonly": [True],
-            "aggnonce": bytes_to_hex(aggnonce_01),
-            "comment": "Single x-only tweak (used for BIP341 Taproot)",
-        },
-        {
-            "tweaks_indices": [0],
-            "is_xonly": [False],
-            "aggnonce": bytes_to_hex(aggnonce_01),
-            "comment": "Single plain tweak (used for BIP32 derivation)",
-        },
-        {
-            "tweaks_indices": [0, 1],
-            "is_xonly": [False, True],
-            "aggnonce": bytes_to_hex(aggnonce_01),
-            "comment": "A plain tweak followed by an x-only tweak",
-        },
-        {
-            "tweaks_indices": [0, 1, 2, 3],
-            "is_xonly": [True, False, True, False],
-            "aggnonce": bytes_to_hex(aggnonce_01),
-            "comment": "Four tweaks alternating x-only and plain",
-        },
-        {
-            "tweaks_indices": [0, 1, 2, 3],
-            "is_xonly": [False, False, True, True],
-            "aggnonce": bytes_to_hex(aggnonce_01),
-            "comment": "Four tweaks: two plain followed by two x-only",
-        },
-        {
-            "tweaks_indices": [0, 1, 2, 3],
-            "is_xonly": [False, False, True, True],
-            "indices": [0, 1, 2],
-            "signer_idx": 1,
-            "aggnonce": bytes_to_hex(aggnonce_012),
-            "comment": "Same tweaks as the previous case but with all 3 signers and signed by a non-first member of the signer set",
-        },
-    ]
-    for case in valid_cases:
-        indices = case.get("indices", [0, 1])
-        curr_ids = [ids[i] for i in indices]
-        curr_pubshares = [pubshares_with_invalid[i] for i in indices]
-        curr_aggnonce = bytes.fromhex(case["aggnonce"])
-        curr_tweaks = [tweaks_pool[i] for i in case["tweaks_indices"]]
-        curr_tweak_modes = case["is_xonly"]
-        signer_idx = case.get("signer_idx", 0)
-        my_id = ids[signer_idx]
-
-        curr_signers = SignersContext(n, t, curr_ids, curr_pubshares, thresh_pk)
-        session_ctx = SessionContext(
-            curr_aggnonce, curr_signers, curr_tweaks, curr_tweak_modes, COMMON_MSGS[0]
+    def _append_valid(
+        self,
+        my_id,
+        ids,
+        pubshare_indices,
+        pubnonce_indices,
+        aggnonce,
+        msg,
+        tweak_indices,
+        is_xonly,
+        comment,
+    ):
+        pubshares = [self.inputs.pubshares[i] for i in pubshare_indices]
+        tweaks = [self.tweaks_pool[i] for i in tweak_indices]
+        secnonce = bytearray(self.inputs.secnonces[my_id])
+        signers = SignersContext(self.n, self.t, ids, pubshares, self.thresh_pk)
+        session = SessionContext(aggnonce, signers, tweaks, is_xonly, msg)
+        psig = sign(secnonce, self.inputs.secshares[my_id], my_id, session)
+        assert partial_sig_verify(
+            psig,
+            [self.inputs.pubnonces[i] for i in pubnonce_indices],
+            signers,
+            tweaks,
+            is_xonly,
+            msg,
+            ids.index(my_id),
         )
-        psig = sign(
-            bytearray(secnonces[signer_idx]), secshares[signer_idx], my_id, session_ctx
-        )
-
-        group["valid_tests"].append(
+        self.group["valid_tests"].append(
             {
-                "tc_id": tc_id,
-                "comment": case["comment"],
+                "comment": comment,
                 "my_id": my_id,
-                "ids": curr_ids,
-                "pubshare_indices": indices,
-                "pubnonce_indices": indices,
-                "secshare_index": signer_idx,
-                "secnonce_index": signer_idx,
-                "aggnonce": case["aggnonce"],
-                "msg": bytes_to_hex(COMMON_MSGS[0]),
-                "tweak_indices": case["tweaks_indices"],
-                "is_xonly": curr_tweak_modes,
+                "ids": ids,
+                "pubshare_indices": pubshare_indices,
+                "pubnonce_indices": pubnonce_indices,
+                "secshare_index": my_id,
+                "secnonce_index": my_id,
+                "aggnonce": bytes_to_hex(aggnonce),
+                "msg": bytes_to_hex(msg),
+                "tweak_indices": tweak_indices,
+                "is_xonly": is_xonly,
                 "expected": bytes_to_hex(psig),
             }
         )
-        tc_id += 1
 
-    # --- Error Test Cases ---
-    error_cases = [
-        {
-            "tweaks_indices": [OUT_OF_RANGE_TWEAK_IDX],
-            "is_xonly": [False],
-            "comment": "Tweak exceeds the group order",
-        },
-        {
-            "tweaks_indices": [INFINITY_TWEAK_IDX],
-            "is_xonly": [False],
-            "comment": "Plain tweak drives the tweaked threshold public key to the point at infinity",
-        },
-        {
-            "tweaks_indices": [0],
-            "is_xonly": [],
-            "comment": "Number of tweaks does not match the number of tweak modes",
-        },
-        {
-            "tweaks_indices": [INVALID_33_BYTE_TWEAK_IDX],
-            "is_xonly": [False],
-            "comment": "Tweak is not a 32-byte array",
-        },
-    ]
-    for case in error_cases:
-        indices = [0, 1]
-        curr_ids = [ids[i] for i in indices]
-        curr_pubshares = [pubshares_with_invalid[i] for i in indices]
-        curr_tweaks = [tweaks_pool[i] for i in case["tweaks_indices"]]
-        curr_tweak_modes = case["is_xonly"]
-        my_id = curr_ids[0]
-
-        curr_signers = SignersContext(n, t, curr_ids, curr_pubshares, thresh_pk)
-        session_ctx = SessionContext(
-            aggnonce_01, curr_signers, curr_tweaks, curr_tweak_modes, COMMON_MSGS[0]
-        )
+    def _append_error(
+        self,
+        my_id,
+        ids,
+        pubshare_indices,
+        secshare_index,
+        secnonce_index,
+        aggnonce,
+        msg,
+        tweak_indices,
+        is_xonly,
+        comment,
+    ):
+        pubshares = [self.inputs.pubshares[i] for i in pubshare_indices]
+        tweaks = [self.tweaks_pool[i] for i in tweak_indices]
+        secnonce = bytearray(self.inputs.secnonces[secnonce_index])
+        secshare = self.inputs.secshares[secshare_index]
+        signers = SignersContext(self.n, self.t, ids, pubshares, self.thresh_pk)
+        session = SessionContext(aggnonce, signers, tweaks, is_xonly, msg)
         error = expect_exception(
-            lambda: sign(bytearray(secnonces[0]), secshares[0], my_id, session_ctx),
-            ValueError,
+            lambda: sign(secnonce, secshare, my_id, session), ValueError
         )
-        group["error_tests"].append(
+        self.group["error_tests"].append(
             {
-                "tc_id": tc_id,
-                "comment": case["comment"],
+                "comment": comment,
                 "my_id": my_id,
-                "ids": curr_ids,
-                "pubshare_indices": indices,
-                "secshare_index": 0,
-                "secnonce_index": 0,
-                "aggnonce": bytes_to_hex(aggnonce_01),
-                "msg": bytes_to_hex(COMMON_MSGS[0]),
-                "tweak_indices": case["tweaks_indices"],
-                "is_xonly": curr_tweak_modes,
+                "ids": ids,
+                "pubshare_indices": pubshare_indices,
+                "secshare_index": secshare_index,
+                "secnonce_index": secnonce_index,
+                "aggnonce": bytes_to_hex(aggnonce),
+                "msg": bytes_to_hex(msg),
+                "tweak_indices": tweak_indices,
+                "is_xonly": is_xonly,
                 "error": error,
             }
         )
-        tc_id += 1
 
-    vectors = {"test_groups": [group]}
-    write_test_vectors("tweak_vectors.json", vectors)
+    # --- Array A: valid_tests ---
+
+    def add_valid_tests(self):
+        msg = COMMON_MSGS[0]
+        aggnonce_min = self._agg(self.min_s)
+        aggnonce_full = self._agg(self.full)
+
+        # No tweaks applied
+        self._append_valid(
+            0,
+            self.min_s,
+            self.min_s,
+            self.min_s,
+            aggnonce_min,
+            msg,
+            [],
+            [],
+            "No tweaks applied",
+        )
+        # Single x-only tweak
+        self._append_valid(
+            0,
+            self.min_s,
+            self.min_s,
+            self.min_s,
+            aggnonce_min,
+            msg,
+            [0],
+            [True],
+            "Single x-only tweak (used for BIP341 Taproot)",
+        )
+        # Single plain tweak
+        self._append_valid(
+            0,
+            self.min_s,
+            self.min_s,
+            self.min_s,
+            aggnonce_min,
+            msg,
+            [0],
+            [False],
+            "Single plain tweak (used for BIP32 derivation)",
+        )
+        # Plain then x-only tweak
+        self._append_valid(
+            0,
+            self.min_s,
+            self.min_s,
+            self.min_s,
+            aggnonce_min,
+            msg,
+            [0, 1],
+            [False, True],
+            "A plain tweak followed by an x-only tweak",
+        )
+        # Four tweaks alternating x-only and plain
+        self._append_valid(
+            0,
+            self.min_s,
+            self.min_s,
+            self.min_s,
+            aggnonce_min,
+            msg,
+            [0, 1, 2, 3],
+            [True, False, True, False],
+            "Four tweaks alternating x-only and plain",
+        )
+        # Four tweaks: two plain then two x-only
+        self._append_valid(
+            0,
+            self.min_s,
+            self.min_s,
+            self.min_s,
+            aggnonce_min,
+            msg,
+            [0, 1, 2, 3],
+            [False, False, True, True],
+            "Four tweaks: two plain followed by two x-only",
+        )
+        # Same tweaks as the previous case but all n signers, signed by non-first member
+        self._append_valid(
+            1,
+            self.full,
+            self.full,
+            self.full,
+            aggnonce_full,
+            msg,
+            [0, 1, 2, 3],
+            [False, False, True, True],
+            "Same tweaks as the previous case but with all signers participating, signed by a non-first member of the signer set",
+        )
+
+    # --- Array B: error_tests ---
+
+    def add_error_tests(self):
+        msg = COMMON_MSGS[0]
+        aggnonce_min = self._agg(self.min_s)
+        my_id = 0
+
+        # Tweak exceeds the group order
+        self._append_error(
+            my_id,
+            self.min_s,
+            self.min_s,
+            0,
+            0,
+            aggnonce_min,
+            msg,
+            [self.inputs.OUT_OF_RANGE_TWEAK_IDX],
+            [False],
+            "Tweak exceeds the group order",
+        )
+        # Infinity tweak
+        self._append_error(
+            my_id,
+            self.min_s,
+            self.min_s,
+            0,
+            0,
+            aggnonce_min,
+            msg,
+            [self.inputs.INFINITY_TWEAK_IDX],
+            [False],
+            "Plain tweak drives the tweaked threshold public key to the point at infinity",
+        )
+        # Length mismatch between tweaks and is_xonly
+        self._append_error(
+            my_id,
+            self.min_s,
+            self.min_s,
+            0,
+            0,
+            aggnonce_min,
+            msg,
+            [0],
+            [],
+            "Number of tweaks does not match the number of tweak modes",
+        )
+        # Invalid 33-byte tweak
+        self._append_error(
+            my_id,
+            self.min_s,
+            self.min_s,
+            0,
+            0,
+            aggnonce_min,
+            msg,
+            [self.INVALID_33_BYTE_TWEAK_IDX],
+            [False],
+            "Tweak is not a 32-byte array",
+        )
+
+    def build(self):
+        self.add_valid_tests()
+        self.add_error_tests()
+        return self.group
+
+
+def generate_tweak_vectors():
+    groups = [TweakGroupBuilder(cfg).build() for cfg in CONFIGS]
+    assign_tc_ids(groups)
+    write_test_vectors("tweak_vectors.json", {"test_groups": groups})

--- a/python/generators/tweak.py
+++ b/python/generators/tweak.py
@@ -29,7 +29,10 @@ INVALID_33_BYTE_TWEAK = bytes.fromhex(
 
 class TweakGroupBuilder:
     """Builds one (t, n) test group for tweak_vectors.json. Shared inputs and
-    subsets live on self. Each add_* method appends its category to self.group."""
+    subsets live on self. Each add_* method appends its category to self.group.
+
+    Index convention: valid cases use secshare_index == secnonce_index == my_id (a
+    signer signs with its own material at pool position my_id)."""
 
     def __init__(self, cfg):
         self.inputs = SharedGroupInputs(cfg)
@@ -42,9 +45,8 @@ class TweakGroupBuilder:
         self.aggnonce_min = self._agg(self.min_s)
 
         # Build the tweaks pool: self.inputs.tweaks_pool has 6 entries (indices 0-5).
-        # Append INVALID_33_BYTE_TWEAK at index 6.
+        # Append INVALID_33_BYTE_TWEAK at the next slot (len of the shared pool).
         self.tweaks_pool = list(self.inputs.tweaks_pool) + [INVALID_33_BYTE_TWEAK]
-        self.INVALID_33_BYTE_TWEAK_IDX = len(self.inputs.tweaks_pool)
 
         self.group = {}
         set_group_config(self.group, cfg, self.inputs)
@@ -291,7 +293,8 @@ class TweakGroupBuilder:
             0,
             self.aggnonce_min,
             msg,
-            [self.INVALID_33_BYTE_TWEAK_IDX],
+            # index of the appended invalid 33-byte tweak (last slot of the pool)
+            [len(self.inputs.tweaks_pool)],
             [False],
             "Tweak is not a 32-byte array",
         )

--- a/python/tests.py
+++ b/python/tests.py
@@ -343,7 +343,11 @@ def test_det_sign_vectors():
                 PlainPk(pubshares[i]) for i in test_case["pubshare_indices"]
             ]
             secshare = secshares[test_case["secshare_index"]]
-            aggothernonce = bytes.fromhex(test_case["aggothernonce"])
+            aggothernonce = (
+                bytes.fromhex(test_case["aggothernonce"])
+                if test_case["aggothernonce"] is not None
+                else None
+            )
             tweaks = fromhex_all(test_case["tweaks"])
             is_xonly = test_case["is_xonly"]
             msg = bytes.fromhex(test_case["msg"])
@@ -370,8 +374,12 @@ def test_det_sign_vectors():
             assert pubnonce == expected[0]
             assert psig == expected[1]
 
-            pubnonces = [aggothernonce, pubnonce]
-            aggnonce_tmp = nonce_agg(pubnonces)
+            # For a sole signer, aggothernonce is None and the aggnonce equals
+            # the signer's own pubnonce; skip the multi-party aggregation path.
+            if aggothernonce is not None:
+                aggnonce_tmp = nonce_agg([pubnonce, aggothernonce])
+            else:
+                aggnonce_tmp = pubnonce
             session_ctx = SessionContext(
                 aggnonce_tmp, signers_tmp, tweaks, is_xonly, msg
             )
@@ -386,7 +394,11 @@ def test_det_sign_vectors():
                 PlainPk(pubshares[i]) for i in test_case["pubshare_indices"]
             ]
             secshare = secshares[test_case["secshare_index"]]
-            aggothernonce = bytes.fromhex(test_case["aggothernonce"])
+            aggothernonce = (
+                bytes.fromhex(test_case["aggothernonce"])
+                if test_case["aggothernonce"] is not None
+                else None
+            )
             tweaks = fromhex_all(test_case["tweaks"])
             is_xonly = test_case["is_xonly"]
             msg = bytes.fromhex(test_case["msg"])

--- a/python/vectors/det_sign_vectors.json
+++ b/python/vectors/det_sign_vectors.json
@@ -19,7 +19,7 @@
             "valid_tests": [
                 {
                     "tc_id": 1,
-                    "comment": "Minimum threshold subset of signers (t=2 of n=3)",
+                    "comment": "Minimum threshold subset of signers",
                     "my_id": 0,
                     "ids": [0, 1],
                     "pubshare_indices": [0, 1],

--- a/python/vectors/det_sign_vectors.json
+++ b/python/vectors/det_sign_vectors.json
@@ -14,7 +14,8 @@
             "secshares": [
                 "53442FA9BD72EEA0A42DF6F2D2D76A2C0D3A3DFA2BE2F820F41ADE976B8259FB",
                 "5A7F9BD41F4B544664C54D777D43303CB5302434F9903B9B552C4E552BF02201",
-                "61BB07FE8123B9EC255CA3FC27AEF64D5D260A6FC73D7F15B63DBE12EC5DEA07"
+                "61BB07FE8123B9EC255CA3FC27AEF64D5D260A6FC73D7F15B63DBE12EC5DEA07",
+                "0000000000000000000000000000000000000000000000000000000000000000"
             ],
             "valid_tests": [
                 {
@@ -104,7 +105,7 @@
                 },
                 {
                     "tc_id": 6,
-                    "comment": "All n=3 signers participate, signed by a non-first member of the signer set",
+                    "comment": "All signers participate, signed by a non-first member of the signer set",
                     "my_id": 1,
                     "ids": [0, 1, 2],
                     "pubshare_indices": [0, 1, 2],
@@ -245,10 +246,10 @@
                 {
                     "tc_id": 14,
                     "comment": "Signer set's public shares do not match the threshold public key",
-                    "my_id": 2,
-                    "ids": [2, 1],
-                    "pubshare_indices": [0, 1],
-                    "secshare_index": 2,
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [1, 0],
+                    "secshare_index": 0,
                     "aggothernonce": "03B5623DAC86C61452568A3351C9BF29E4B9689338D2A96E0990306C9FFE6A640A034672C929A954E04F109C90EC415790D8463C8A43A84ABE39CC302E07299D95E0",
                     "rand": "0000000000000000000000000000000000000000000000000000000000000000",
                     "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
@@ -348,6 +349,1052 @@
                     "error": {
                         "type": "ValueError",
                         "message": "The tweak value is out of range."
+                    }
+                },
+                {
+                    "tc_id": 20,
+                    "comment": "Secret share is out of range (zero)",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "secshare_index": 3,
+                    "aggothernonce": "03B5623DAC86C61452568A3351C9BF29E4B9689338D2A96E0990306C9FFE6A640A034672C929A954E04F109C90EC415790D8463C8A43A84ABE39CC302E07299D95E0",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's secret share value is out of range."
+                    }
+                }
+            ]
+        },
+        {
+            "tg_id": "1of3",
+            "t": 1,
+            "n": 3,
+            "thresh_pk": "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F",
+            "pubshares": [
+                "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F",
+                "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F",
+                "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F",
+                "020000000000000000000000000000000000000000000000000000000000000007"
+            ],
+            "secshares": [
+                "06D47E05E97481428654563E5AE69C20C49642773B7334220E63110259A30C32",
+                "06D47E05E97481428654563E5AE69C20C49642773B7334220E63110259A30C32",
+                "06D47E05E97481428654563E5AE69C20C49642773B7334220E63110259A30C32",
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            ],
+            "valid_tests": [
+                {
+                    "tc_id": 21,
+                    "comment": "Minimum threshold subset of signers",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "aggothernonce": null,
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "0295E62D67F98EE3F9349DDA8D39B6668BAF6F25E195135570FEC4E16725FE0DCD02667A763E416AF318B98A5D02ED80E89448049EFA66FAE73F6DAC30A998CF4399",
+                        "5C07FF4B850F51D7377BD96AA8622AF2FB53524AFA4946549297FE6511D5A964"
+                    ]
+                },
+                {
+                    "tc_id": 22,
+                    "comment": "Reordering the signer set leaves the deterministic output unchanged, because the identifiers are sorted before they are bound into the nonce derivation and the binding value",
+                    "my_id": 0,
+                    "ids": [1, 0],
+                    "pubshare_indices": [1, 0],
+                    "secshare_index": 0,
+                    "aggothernonce": "03BF06149B3E614403EA899F37446B294117785D15D238E1E36989F294120200A20329620EA331F70450B94A7F6B175CF7C5A65CD967D367332AFD4C6FE514882467",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "03A55B71964F153C99D39943FE37EDFFF9BC3EC6AE7F4E69F5741DE5949C832B8103CA011355A4B233079418F0FC5EFC46FFBAC3300C03381214AC60E87C0DDEF5F8",
+                        "503DF17B008B051197BBFE15CF301134A6017E57E4E76C3A0C06D61226DA1A8F"
+                    ]
+                },
+                {
+                    "tc_id": 23,
+                    "comment": "A different threshold subset gives a different deterministic nonce, since the signer set is bound into the nonce derivation",
+                    "my_id": 1,
+                    "ids": [1],
+                    "pubshare_indices": [1],
+                    "secshare_index": 1,
+                    "aggothernonce": null,
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "03B5E55DDBE3A791BA40A5881EB4A2D2BA9B879EC39216BB60FDF394A9B8839CBB0343606BD07944F95CA73C0C890E1EE2884C65AA8185C9953692EAA47AD34B4227",
+                        "C5F9B723C432DB9C496A0DA3F5FB48C341EA5AFE6573E43B5DE33F0E27D1767B"
+                    ]
+                },
+                {
+                    "tc_id": 24,
+                    "comment": "Auxiliary randomness omitted (null), which is not equivalent to all-zeros randomness",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "aggothernonce": null,
+                    "rand": null,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "02268A199CEA08BA3353C03D92A9D5889634BD2FC7614066B421939546D511C8BA03FC8189752FDB334AAC103CAC323A8110F900C160A9DE5809BCA290019496BB55",
+                        "9AE1CCA2D19EFF42ECE9FA772DD0D862C03FAD9949FEC071AAA17FB747B224AA"
+                    ]
+                },
+                {
+                    "tc_id": 25,
+                    "comment": "Auxiliary randomness is all ones, distinct from the all-zeros and omitted cases",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "aggothernonce": null,
+                    "rand": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "034C929B5FF1A32312344DBDB4CE731CB5F4BB5904BC6C4DAB06EE628161869F2903853322C0E04E7471C13BDD043AD379D0EF5868F6D15916AA9D93AC8411DEF138",
+                        "CC0EEDC95C48F83DA37EC15634B46B3D3B8FD118B506A13C4A8F03D272E66B12"
+                    ]
+                },
+                {
+                    "tc_id": 26,
+                    "comment": "All signers participate, signed by a non-first member of the signer set",
+                    "my_id": 1,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 1,
+                    "aggothernonce": "02BC6B50C4473EDA599339E76D9F1E4A970BB19B251EADE838C6ADF90347C7A14503294335962373C72A433F05B4921A74316DF9FE84999BEA55B28EF4CD83638FC6",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "036EAB069C1F2C264EF7F15BD142F822EC776E861088D64713007C0366ABB1A73903538966A30A0A1A1C0E6E719298A4C2D55F6E82E759ABC9DAFD6577706BFEA0F9",
+                        "D8BE02C445BF9F327EE989A8859EBF411684D229DA455C954EE90F7EDDC4CBBA"
+                    ]
+                },
+                {
+                    "tc_id": 27,
+                    "comment": "Empty message",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "aggothernonce": null,
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "038E64312D0DD47322D26C9B254E76FB496720D57C07493C5B4329B72A2E128A7B02E62E844D742B01F432B205545C441ED526F433F245F604BBC291A9B81F183F1E",
+                        "F9736615BD6368C21F2FADAD40346D5B561E3DFBD9B08CB80587DA965AC605C6"
+                    ]
+                },
+                {
+                    "tc_id": 28,
+                    "comment": "Non-standard message length (38 bytes)",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "aggothernonce": null,
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "2626262626262626262626262626262626262626262626262626262626262626262626262626",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "03CCE578EABEBA27ACF60873B6CF566F4561614336E73C80CB8313D47DAC01229F022F48D9E1A4F927849C3361BDD259475076D7F4D75829D914625E0515FEC4ADE9",
+                        "848FF2549F3A2527F974C65915B6157DC175500B09FB0FD4F3A044D7E8B4175C"
+                    ]
+                },
+                {
+                    "tc_id": 29,
+                    "comment": "Single x-only tweak applied",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "aggothernonce": null,
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [
+                        "E8F791FF9225A2AF0102AFFF4A9A723D9612A682A25EBE79802B263CDFCD83BB"
+                    ],
+                    "is_xonly": [true],
+                    "expected": [
+                        "02678CE16AAC46533D375EA5D3E9A1220F7614074D341E2D6DA3A59695D87D85C90315E6229EDA7816AF02163957247D1CF9161E2A975EE04E76B594C6EA45F358B8",
+                        "C5EB76498241CAECCF2E85041E3A43650EF7D0363D6916EECB0695D1DB76399E"
+                    ]
+                }
+            ],
+            "error_tests": [
+                {
+                    "tc_id": 30,
+                    "comment": "my_id is not in the signer set",
+                    "my_id": 1,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "aggothernonce": null,
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's id must be present in the participant identifier list."
+                    }
+                },
+                {
+                    "tc_id": 31,
+                    "comment": "Signer set contains a duplicate id",
+                    "my_id": 0,
+                    "ids": [0, 1, 1],
+                    "pubshare_indices": [0, 1, 1],
+                    "secshare_index": 0,
+                    "aggothernonce": "02BC6B50C4473EDA599339E76D9F1E4A970BB19B251EADE838C6ADF90347C7A14503294335962373C72A433F05B4921A74316DF9FE84999BEA55B28EF4CD83638FC6",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The participant identifier list contains duplicate elements."
+                    }
+                },
+                {
+                    "tc_id": 32,
+                    "comment": "A public share is not a valid point",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 3],
+                    "secshare_index": 0,
+                    "aggothernonce": "03BF06149B3E614403EA899F37446B294117785D15D238E1E36989F294120200A20329620EA331F70450B94A7F6B175CF7C5A65CD967D367332AFD4C6FE514882467",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "Invalid pubshare at index 1."
+                    }
+                },
+                {
+                    "tc_id": 33,
+                    "comment": "Aggregate of the other signers' nonces is invalid: first half has an unknown tag 0x04",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "secshare_index": 0,
+                    "aggothernonce": "048465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61037496A3CC86926D452CAFCFD55D25972CA1675D549310DE296BFF42F72EEEA8C9",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggothernonce"
+                    }
+                },
+                {
+                    "tc_id": 34,
+                    "comment": "Aggregate of the other signers' nonces is invalid: first half is all zeros",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "secshare_index": 0,
+                    "aggothernonce": "0000000000000000000000000000000000000000000000000000000000000000000287BF891D2A6DEAEBADC909352AA9405D1428C15F4B75F04DAE642A95C2548480",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggothernonce"
+                    }
+                },
+                {
+                    "tc_id": 35,
+                    "comment": "Aggregate of the other signers' nonces is invalid: second half is not a point on the curve",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "secshare_index": 0,
+                    "aggothernonce": "0353BC2314D46C813AF81317AF1BDF99816B6444E416BB8D3DC04ACB2F5388D1AC020000000000000000000000000000000000000000000000000000000000000009",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggothernonce"
+                    }
+                },
+                {
+                    "tc_id": 36,
+                    "comment": "Aggregate of the other signers' nonces is invalid: second half's x-coordinate exceeds the field size",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "secshare_index": 0,
+                    "aggothernonce": "0353BC2314D46C813AF81317AF1BDF99816B6444E416BB8D3DC04ACB2F5388D1AC02FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggothernonce"
+                    }
+                },
+                {
+                    "tc_id": 37,
+                    "comment": "Tweak exceeds the group order",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "aggothernonce": null,
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [
+                        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
+                    ],
+                    "is_xonly": [false],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The tweak value is out of range."
+                    }
+                },
+                {
+                    "tc_id": 38,
+                    "comment": "Secret share is out of range (zero)",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 3,
+                    "aggothernonce": null,
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's secret share value is out of range."
+                    }
+                }
+            ]
+        },
+        {
+            "tg_id": "3of3",
+            "t": 3,
+            "n": 3,
+            "thresh_pk": "023E94D6A68620D3F60221A4186786274A711221A8BBB31A5388DFA6718E8EF7BB",
+            "pubshares": [
+                "03A3E932BA9DD0063D721590B6EF21DD4566A97B203343FDE9DA5815DB9BE049CA",
+                "0201E5FEAC0DB5059C32B045F37799101A96262B3C88CE85D610451FC21A0457FF",
+                "03EF72D10D1DFE4E786619536A458507CAF105FCCDB8173DAF2E358054AF2FA4A2",
+                "020000000000000000000000000000000000000000000000000000000000000007"
+            ],
+            "secshares": [
+                "D4DE571C662C319E7C4F46420F5ACBEFD2D905C3B52771C553DE1F76197D940D",
+                "0EAAC017ABA2030272B7F8EAAD68E22BF07F08950D7B570B69B2CCEF278D52C1",
+                "1E4E4344B9B59410588CCF327B766E4D298882D904F0FBF288C86B73AC5962A3",
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            ],
+            "valid_tests": [
+                {
+                    "tc_id": 39,
+                    "comment": "Minimum threshold subset of signers",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "0332B7FBB7F9A16AD4073FF482BF6F77A2943099FA5C2B691CA9002C39EC7249F3030FB4D9D5D74D2DEEDBA77ED1F16EF277769A12F57117EA0A0B999905FB0A042C",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "02B80EAFA062C4F9C47F361E815D569569F1380C870002139CDEE079080681EE6C03ED14FF4C014894D392529D35FACA5994FB7D147FB232F05D67184498053AF9AA",
+                        "55C05DB762676CD9E26A1681863C54DC53EE8E86DD831D0013F1E2459B2DA4C3"
+                    ]
+                },
+                {
+                    "tc_id": 40,
+                    "comment": "Reordering the signer set leaves the deterministic output unchanged, because the identifiers are sorted before they are bound into the nonce derivation and the binding value",
+                    "my_id": 0,
+                    "ids": [2, 1, 0],
+                    "pubshare_indices": [2, 1, 0],
+                    "secshare_index": 0,
+                    "aggothernonce": "0332B7FBB7F9A16AD4073FF482BF6F77A2943099FA5C2B691CA9002C39EC7249F3030FB4D9D5D74D2DEEDBA77ED1F16EF277769A12F57117EA0A0B999905FB0A042C",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "02B80EAFA062C4F9C47F361E815D569569F1380C870002139CDEE079080681EE6C03ED14FF4C014894D392529D35FACA5994FB7D147FB232F05D67184498053AF9AA",
+                        "55C05DB762676CD9E26A1681863C54DC53EE8E86DD831D0013F1E2459B2DA4C3"
+                    ]
+                },
+                {
+                    "tc_id": 41,
+                    "comment": "Auxiliary randomness omitted (null), which is not equivalent to all-zeros randomness",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "02198622491E3A0971DDD3E3942FF4CB87DD93C89F44E64F2F8EC67FEA87F7784103C76826C434E8FD7FC97035A02A48B69216E4C9B7B7D12E5F610932D684B97918",
+                    "rand": null,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "03CA9BF0AC6D0D53ED0462C460C0039AD2D9110E989936B0449FFD1D5CC9951B340277D02C4310270F0E8A88C1D4EC6ABF1BC3EC1115A318DECD42B9DB63383A8DC0",
+                        "C434DDAEBDF29FE18CE077ADE6205F4BEC11F0E882C445FC700AE2B7A81DAF07"
+                    ]
+                },
+                {
+                    "tc_id": 42,
+                    "comment": "Auxiliary randomness is all ones, distinct from the all-zeros and omitted cases",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "030ED1C876E4F01533A8D4BAB57F066F1F524683B9780D410D95156AA2FF338C1703D1220C19343CD26DAFC53FA70AD7F2D2FB9D0916DE8CDAD71A6538E62E2DA73C",
+                    "rand": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "03F2403F95C7EE842EFBF0F97F9C10475ACF040524BFD330A814698FB02DF9799E0334170AB7D14732FA2715D80F9837C065C94C7D01B3AF1D88ADBDF977B857C98C",
+                        "5541CEB56A7553A0DA7D74B721B33A2AAC63C149A4FA9591FDE20156D40013B1"
+                    ]
+                },
+                {
+                    "tc_id": 43,
+                    "comment": "All signers participate, signed by a non-first member of the signer set",
+                    "my_id": 1,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 1,
+                    "aggothernonce": "03D14459A3411BADB6C14B482BC173A8BBF644AC6274F7270419DC7C7967DD66BC0254E13581A0CCB65293AE69B3C070CC68AF13379805CBDE72809BA9A354683CAE",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "02A1D0B9E85635BD87697EAF55DD319FACAE2E991C42336E6B6535FDC0932162B802A9B35155A8E77D0BCC8D5C47ECBCE37A6D0C7BB5CF0B2DD7B116512148CEC436",
+                        "4D6720C084EE12026358BCA287B63602F9BA3871CFE65656C05D1ED53C558105"
+                    ]
+                },
+                {
+                    "tc_id": 44,
+                    "comment": "Empty message",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "03DBEC1DF71805A741A07100BEE788344F006ECBFDF4D65E14CB18A73638D547F403F1379806F19A84BD49BE1FB02DB1EE7B149FE2362D990FADCEA3143AFB89B0B3",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "03936EB45747FE9068DBC6D2D86FBB979D625D617F20519A6DDD1FE25591A491B303DCE086739A87DD04D97B7042DDDF217FFED3665C1D151735EA17B6A78068FD33",
+                        "4D0F98ED886C019D6C4C47E5C30C5967D9D59EC57820EA9181270F944523A3EC"
+                    ]
+                },
+                {
+                    "tc_id": 45,
+                    "comment": "Non-standard message length (38 bytes)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "023E91D85064879ACA2EB0A1B1ACEEDAF5FF75B00BCE775552A012DD3D533A835E03A566DDF1C7C6C9059F6ED07E81C6F9E074DBC54E873E9EFE78DE1500CAF2D482",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "2626262626262626262626262626262626262626262626262626262626262626262626262626",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "020BBE6991AF738E91119B5241B1BD00910CEC723A05C95F775B7F887D67D25FBD02F20C39B93C39D2CC6035C16D9D1FA38BCBC7B1B528355C6E4CF910944EBD09A6",
+                        "8FC473EF9A9BE1F6599AF017B5575C983C912E15936E39CD708A651D80DDEA1F"
+                    ]
+                },
+                {
+                    "tc_id": 46,
+                    "comment": "Single x-only tweak applied",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "0332B7FBB7F9A16AD4073FF482BF6F77A2943099FA5C2B691CA9002C39EC7249F3030FB4D9D5D74D2DEEDBA77ED1F16EF277769A12F57117EA0A0B999905FB0A042C",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [
+                        "E8F791FF9225A2AF0102AFFF4A9A723D9612A682A25EBE79802B263CDFCD83BB"
+                    ],
+                    "is_xonly": [true],
+                    "expected": [
+                        "03E2DC20E1BF882B1B2E6ADC6405714F92378151E663F019D8AEC40B9E5EF422CE0260D4CE00C2E0BC5AA5282FC974E8460E08154AD7E9316CED832981561F0267C7",
+                        "E9DEC4131FCB84DAEAEDDDD0DFAA84E4D9E6C902AB63C7BB9BB5F1CB13697ACE"
+                    ]
+                }
+            ],
+            "error_tests": [
+                {
+                    "tc_id": 47,
+                    "comment": "Signer set contains a duplicate id",
+                    "my_id": 0,
+                    "ids": [0, 1, 1],
+                    "pubshare_indices": [0, 1, 1],
+                    "secshare_index": 0,
+                    "aggothernonce": "037898008EFDB2DF4EC5D990A7461FBC51B9D35E6F9F06F2424F77F74D0DB6C49402A1958475AE7073DBE8C699A41BD543DD102671A7CDBC1241C4F613D13865A7E1",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The participant identifier list contains duplicate elements."
+                    }
+                },
+                {
+                    "tc_id": 48,
+                    "comment": "A public share is not a valid point",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 3, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "0332B7FBB7F9A16AD4073FF482BF6F77A2943099FA5C2B691CA9002C39EC7249F3030FB4D9D5D74D2DEEDBA77ED1F16EF277769A12F57117EA0A0B999905FB0A042C",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "Invalid pubshare at index 1."
+                    }
+                },
+                {
+                    "tc_id": 49,
+                    "comment": "Signer set's public shares do not match the threshold public key",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 2, 1],
+                    "secshare_index": 0,
+                    "aggothernonce": "0332B7FBB7F9A16AD4073FF482BF6F77A2943099FA5C2B691CA9002C39EC7249F3030FB4D9D5D74D2DEEDBA77ED1F16EF277769A12F57117EA0A0B999905FB0A042C",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The provided key material is incorrect."
+                    }
+                },
+                {
+                    "tc_id": 50,
+                    "comment": "Aggregate of the other signers' nonces is invalid: first half has an unknown tag 0x04",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "048465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61037496A3CC86926D452CAFCFD55D25972CA1675D549310DE296BFF42F72EEEA8C9",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggothernonce"
+                    }
+                },
+                {
+                    "tc_id": 51,
+                    "comment": "Aggregate of the other signers' nonces is invalid: first half is all zeros",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "0000000000000000000000000000000000000000000000000000000000000000000287BF891D2A6DEAEBADC909352AA9405D1428C15F4B75F04DAE642A95C2548480",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggothernonce"
+                    }
+                },
+                {
+                    "tc_id": 52,
+                    "comment": "Aggregate of the other signers' nonces is invalid: second half is not a point on the curve",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "0353BC2314D46C813AF81317AF1BDF99816B6444E416BB8D3DC04ACB2F5388D1AC020000000000000000000000000000000000000000000000000000000000000009",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggothernonce"
+                    }
+                },
+                {
+                    "tc_id": 53,
+                    "comment": "Aggregate of the other signers' nonces is invalid: second half's x-coordinate exceeds the field size",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "0353BC2314D46C813AF81317AF1BDF99816B6444E416BB8D3DC04ACB2F5388D1AC02FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggothernonce"
+                    }
+                },
+                {
+                    "tc_id": 54,
+                    "comment": "Tweak exceeds the group order",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "0332B7FBB7F9A16AD4073FF482BF6F77A2943099FA5C2B691CA9002C39EC7249F3030FB4D9D5D74D2DEEDBA77ED1F16EF277769A12F57117EA0A0B999905FB0A042C",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [
+                        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
+                    ],
+                    "is_xonly": [false],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The tweak value is out of range."
+                    }
+                },
+                {
+                    "tc_id": 55,
+                    "comment": "Secret share is out of range (zero)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 3,
+                    "aggothernonce": "0332B7FBB7F9A16AD4073FF482BF6F77A2943099FA5C2B691CA9002C39EC7249F3030FB4D9D5D74D2DEEDBA77ED1F16EF277769A12F57117EA0A0B999905FB0A042C",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's secret share value is out of range."
+                    }
+                }
+            ]
+        },
+        {
+            "tg_id": "3of5",
+            "t": 3,
+            "n": 5,
+            "thresh_pk": "03E1AEA00A7B8D0E0393664FEBBD31569A02CAF223D9AD83E90331DC18B1987358",
+            "pubshares": [
+                "02F333EDD2B6F532C2EF6C42E803B633A42289D0567A75C50EB1C8CF85EC480E8F",
+                "025322F63602ECCF146541B7C9EE4D1FCB84EC139471420472182AE968676A387F",
+                "0230639CEC0A83982E176D6905CE0620FDC57E151565A39D0E0821B8E753AE85B0",
+                "026E1A50E672FEDD3F3C378D6121E5702B050669DBC241D2C2299880152CD207BD",
+                "02DC06C4CA919DE70B4B8281901CCF9471AB91FBFBEE1A8C570D83911CAAF9E2FA",
+                "020000000000000000000000000000000000000000000000000000000000000007"
+            ],
+            "secshares": [
+                "77C9316A64770B17D500840E020A9478F793D37DB0E6A276CB4E6270187D6C90",
+                "74180420A784189B55F8C4667075E89C2064FF481B6ED2A23A7517AF71F6B7A8",
+                "BE6B9FB07586EBABD234EEE0A05E813DFFC14D73782085C8DFE77C1FADDA7172",
+                "56C40419CE7F844949B5037C91C45E5FDAF9E11917B31BAEFBD33133FBF258AD",
+                "3D21315CB26DE273BC79023A44A780006CBD971FA96F34904E0A95792C74AE9A",
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            ],
+            "valid_tests": [
+                {
+                    "tc_id": 56,
+                    "comment": "Minimum threshold subset of signers",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "0219F17947F46DF47FF6498266840A3EB4EB3C000842A77AFF629133255674C92E0344A483E63F20FFD037A3BCA53ADF552549DF79D64F3DCF89596B7037B856C1E4",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "03A10647D6B61EF5CAF27F4EC071B1E7ACF45EC2A55FE686F38B24FD7C36D5A2BF033AB814157913499001873909DA7843DDCEC15E64DFE9C3AC9080C3322183624A",
+                        "68797978D8A3808FFFD609D37AEC851551B86169B645287200916F1033E617D0"
+                    ]
+                },
+                {
+                    "tc_id": 57,
+                    "comment": "Reordering the signer set leaves the deterministic output unchanged, because the identifiers are sorted before they are bound into the nonce derivation and the binding value",
+                    "my_id": 0,
+                    "ids": [2, 1, 0],
+                    "pubshare_indices": [2, 1, 0],
+                    "secshare_index": 0,
+                    "aggothernonce": "0219F17947F46DF47FF6498266840A3EB4EB3C000842A77AFF629133255674C92E0344A483E63F20FFD037A3BCA53ADF552549DF79D64F3DCF89596B7037B856C1E4",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "03A10647D6B61EF5CAF27F4EC071B1E7ACF45EC2A55FE686F38B24FD7C36D5A2BF033AB814157913499001873909DA7843DDCEC15E64DFE9C3AC9080C3322183624A",
+                        "68797978D8A3808FFFD609D37AEC851551B86169B645287200916F1033E617D0"
+                    ]
+                },
+                {
+                    "tc_id": 58,
+                    "comment": "A different threshold subset gives a different deterministic nonce, since the signer set is bound into the nonce derivation",
+                    "my_id": 0,
+                    "ids": [0, 3, 4],
+                    "pubshare_indices": [0, 3, 4],
+                    "secshare_index": 0,
+                    "aggothernonce": "03BD60BBC5F251F988DA82505A0025C0B2AC9D90FE1708CDC6AF73A2D505120FFA032EA935A597AE9A6FFA87238B5E5B19D99B82DAFD2E63FBDF79405D8804B0BEA5",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "03F3BF166F7258AF832B72C2B638C0712E62B0777B79A052C6B0B2E848475874B60327E180064432D0555554BD18601D0DAAEB74A49213D40493FBB752FB7C720C27",
+                        "922462449E0A993EB778CCFA77D4EFCF8C44A6461845DF9A48508402EE4DE4D3"
+                    ]
+                },
+                {
+                    "tc_id": 59,
+                    "comment": "Auxiliary randomness omitted (null), which is not equivalent to all-zeros randomness",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "0370EDEFE5A151F0300A2D5B0D4DEB852FCFA6FF5A51C49F2C165CDC89039BAEA3027EBD4CF587854DFF6E7E543A0F2946100EAFA06BA7725A5274FB3FFF51B44E12",
+                    "rand": null,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "02D1D64CCA49F6176E4004A613D77BF13CCC269ACA131C30731D6B57ECD16CDC350259C6BB03EE92FC0AC2966F7C0710A9F080963F5C2D9D5656796D14255E33BBA4",
+                        "04BE5D6944441D05B1BA9633A184C9DEACA8820C56F87E641EC4028466DF674B"
+                    ]
+                },
+                {
+                    "tc_id": 60,
+                    "comment": "Auxiliary randomness is all ones, distinct from the all-zeros and omitted cases",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "02C578DB2BCA4288BAE8C820EFCAB44F1F71007060AE30AB53626B851E93EC4D3A037C5FB4E1AE08FCC48CF4FE5A6A07D9BAFA450A832427C49E4AC07FBAFE0391CF",
+                    "rand": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "03290D3ABEE38251286025A8481C0E1075B2FA0B0CA1DFFB5CA7BF29B6E497241C020A86452ADC52036AD06D2E0CFB8704998C65AA7AE130EF79C9D2805C566BC5FA",
+                        "D79FF828EBEF3ED9E83F612B1B3C4BB30D5FA96E79B500353A8ADA4146D8E7D8"
+                    ]
+                },
+                {
+                    "tc_id": 61,
+                    "comment": "All signers participate, signed by a non-first member of the signer set",
+                    "my_id": 1,
+                    "ids": [0, 1, 2, 3, 4],
+                    "pubshare_indices": [0, 1, 2, 3, 4],
+                    "secshare_index": 1,
+                    "aggothernonce": "031B2116862A490740D7082F477A81EC2410A68C39BFBD38B50978C80E4A2BFD2802A769A1EF6EC7295F19040BF0193BD21692977215C9B9332D18AD815205EE483D",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "02351BDA5BEEC231E09483237F67D7EABC006E3C386B6BF8303951EA14045E2ADF030E49F36C12A2467EE777BF76D3EEFBE53FAB399F0F5EB08B9B89BD20B3586248",
+                        "34B68A4510C7488AC9DD421B926E3F4C5C83A40446A3244E6E542ED40480D7DD"
+                    ]
+                },
+                {
+                    "tc_id": 62,
+                    "comment": "Empty message",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "024C00C326A19D4FD350BDA2215C6106EA7F6EDBED39FACA843D63BA0818C29BC102F60801C2F53CAA17A3178827BFE54227910548C5763F4128ACE98B35F5DB920E",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "02C53EF94A81C740959954BA92112638EA9F2FAA82A52141246275EF91EC6C6BFB0207B251CEB4045FBBBF6D64A85A06FDB9DE2B79F9599E4E1CA9617379713A5EBA",
+                        "FBC611CE731AF8DD0864F697398696A1BF7A5F43860014CB2EA4B48DAA26F24C"
+                    ]
+                },
+                {
+                    "tc_id": 63,
+                    "comment": "Non-standard message length (38 bytes)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "039509DFFF34C4536958557301E50BA8F46EEA1CC9C3AF0543F748F2287666F0F4038659DC107436BD5CACC6019DE0DDB6FAA1762D9AC01A0A8CE792EDB5A17C4CE0",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "2626262626262626262626262626262626262626262626262626262626262626262626262626",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "expected": [
+                        "0298A8254793996B39880389EAC21A24E698BD5F723E83857EB8926DFFF22B10A9024B32BC14A48B2E7B2CDEBA207C77E34EC8EB394C34D1F9640813596FB5F9961A",
+                        "11440936EFF97E326102806F539D929EB49078D2C8EB66902DB1D824863FF6DB"
+                    ]
+                },
+                {
+                    "tc_id": 64,
+                    "comment": "Single x-only tweak applied",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "0219F17947F46DF47FF6498266840A3EB4EB3C000842A77AFF629133255674C92E0344A483E63F20FFD037A3BCA53ADF552549DF79D64F3DCF89596B7037B856C1E4",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [
+                        "E8F791FF9225A2AF0102AFFF4A9A723D9612A682A25EBE79802B263CDFCD83BB"
+                    ],
+                    "is_xonly": [true],
+                    "expected": [
+                        "0310B14CBDD8E9319442C239353AC24AD698C60288879ADAD357BF4ACD4A7C8DB70290D0199D6C7BA8A3D72462D9AAB70150BE92E54FD031EDE2116725944C1C07B7",
+                        "89112CF4A4D87E1BDF3D33BD6847DDD09874D7EC1BA237F9BD64097FB5179F74"
+                    ]
+                }
+            ],
+            "error_tests": [
+                {
+                    "tc_id": 65,
+                    "comment": "my_id is not in the signer set",
+                    "my_id": 3,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "026FA8A1E96458EF85245011687718880BD474A2433618437ED67ABAF2D12C5A6A03183F1777ED7434F02421F8391597736124D3EC38B21C98F1FF5F01A5B4BE196F",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's id must be present in the participant identifier list."
+                    }
+                },
+                {
+                    "tc_id": 66,
+                    "comment": "Signer set contains a duplicate id",
+                    "my_id": 0,
+                    "ids": [0, 1, 1],
+                    "pubshare_indices": [0, 1, 1],
+                    "secshare_index": 0,
+                    "aggothernonce": "02DB1AFDB69CAB66CDBE9DD45F0487E51E72238F1E2FA6F1C468E19153C538115B026BA7F81DFD36E6787962FCA76C754B54B02BB3BF314313D2189214FAEFF7E724",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The participant identifier list contains duplicate elements."
+                    }
+                },
+                {
+                    "tc_id": 67,
+                    "comment": "Signer's public share is not in the public share list",
+                    "my_id": 1,
+                    "ids": [1, 2, 3],
+                    "pubshare_indices": [1, 2, 3],
+                    "secshare_index": 0,
+                    "aggothernonce": "03CC8D9E200DF6C735AD179221FF4425B00744556C77BA0A89E6DD710E1103686002F8DB2417FAA2FF7696322094471DEF9352A8DE601B3EA267A59089B49A4C294A",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's pubshare must be included in the list of pubshares."
+                    }
+                },
+                {
+                    "tc_id": 68,
+                    "comment": "A public share is not a valid point",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 5, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "0219F17947F46DF47FF6498266840A3EB4EB3C000842A77AFF629133255674C92E0344A483E63F20FFD037A3BCA53ADF552549DF79D64F3DCF89596B7037B856C1E4",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "Invalid pubshare at index 1."
+                    }
+                },
+                {
+                    "tc_id": 69,
+                    "comment": "Signer set's public shares do not match the threshold public key",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 2, 1],
+                    "secshare_index": 0,
+                    "aggothernonce": "0219F17947F46DF47FF6498266840A3EB4EB3C000842A77AFF629133255674C92E0344A483E63F20FFD037A3BCA53ADF552549DF79D64F3DCF89596B7037B856C1E4",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The provided key material is incorrect."
+                    }
+                },
+                {
+                    "tc_id": 70,
+                    "comment": "Aggregate of the other signers' nonces is invalid: first half has an unknown tag 0x04",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "048465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61037496A3CC86926D452CAFCFD55D25972CA1675D549310DE296BFF42F72EEEA8C9",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggothernonce"
+                    }
+                },
+                {
+                    "tc_id": 71,
+                    "comment": "Aggregate of the other signers' nonces is invalid: first half is all zeros",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "0000000000000000000000000000000000000000000000000000000000000000000287BF891D2A6DEAEBADC909352AA9405D1428C15F4B75F04DAE642A95C2548480",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggothernonce"
+                    }
+                },
+                {
+                    "tc_id": 72,
+                    "comment": "Aggregate of the other signers' nonces is invalid: second half is not a point on the curve",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "0353BC2314D46C813AF81317AF1BDF99816B6444E416BB8D3DC04ACB2F5388D1AC020000000000000000000000000000000000000000000000000000000000000009",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggothernonce"
+                    }
+                },
+                {
+                    "tc_id": 73,
+                    "comment": "Aggregate of the other signers' nonces is invalid: second half's x-coordinate exceeds the field size",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "0353BC2314D46C813AF81317AF1BDF99816B6444E416BB8D3DC04ACB2F5388D1AC02FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggothernonce"
+                    }
+                },
+                {
+                    "tc_id": 74,
+                    "comment": "Tweak exceeds the group order",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "aggothernonce": "0219F17947F46DF47FF6498266840A3EB4EB3C000842A77AFF629133255674C92E0344A483E63F20FFD037A3BCA53ADF552549DF79D64F3DCF89596B7037B856C1E4",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [
+                        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
+                    ],
+                    "is_xonly": [false],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The tweak value is out of range."
+                    }
+                },
+                {
+                    "tc_id": 75,
+                    "comment": "Secret share is out of range (zero)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 5,
+                    "aggothernonce": "0219F17947F46DF47FF6498266840A3EB4EB3C000842A77AFF629133255674C92E0344A483E63F20FFD037A3BCA53ADF552549DF79D64F3DCF89596B7037B856C1E4",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's secret share value is out of range."
                     }
                 }
             ]

--- a/python/vectors/det_sign_vectors.json
+++ b/python/vectors/det_sign_vectors.json
@@ -441,40 +441,6 @@
                 },
                 {
                     "tc_id": 24,
-                    "comment": "Reordering the signer set leaves the deterministic output unchanged, because the identifiers are sorted before they are bound into the nonce derivation and the binding value",
-                    "my_id": 0,
-                    "ids": [1, 0],
-                    "pubshare_indices": [1, 0],
-                    "secshare_index": 0,
-                    "aggothernonce": "03BF06149B3E614403EA899F37446B294117785D15D238E1E36989F294120200A20329620EA331F70450B94A7F6B175CF7C5A65CD967D367332AFD4C6FE514882467",
-                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
-                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
-                    "tweaks": [],
-                    "is_xonly": [],
-                    "expected": [
-                        "03A55B71964F153C99D39943FE37EDFFF9BC3EC6AE7F4E69F5741DE5949C832B8103CA011355A4B233079418F0FC5EFC46FFBAC3300C03381214AC60E87C0DDEF5F8",
-                        "503DF17B008B051197BBFE15CF301134A6017E57E4E76C3A0C06D61226DA1A8F"
-                    ]
-                },
-                {
-                    "tc_id": 25,
-                    "comment": "A different threshold subset gives a different deterministic nonce, since the signer set is bound into the nonce derivation",
-                    "my_id": 1,
-                    "ids": [1],
-                    "pubshare_indices": [1],
-                    "secshare_index": 1,
-                    "aggothernonce": null,
-                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
-                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
-                    "tweaks": [],
-                    "is_xonly": [],
-                    "expected": [
-                        "03B5E55DDBE3A791BA40A5881EB4A2D2BA9B879EC39216BB60FDF394A9B8839CBB0343606BD07944F95CA73C0C890E1EE2884C65AA8185C9953692EAA47AD34B4227",
-                        "C5F9B723C432DB9C496A0DA3F5FB48C341EA5AFE6573E43B5DE33F0E27D1767B"
-                    ]
-                },
-                {
-                    "tc_id": 26,
                     "comment": "Auxiliary randomness omitted (null), which is not equivalent to all-zeros randomness",
                     "my_id": 0,
                     "ids": [0],
@@ -491,7 +457,7 @@
                     ]
                 },
                 {
-                    "tc_id": 27,
+                    "tc_id": 25,
                     "comment": "Auxiliary randomness is all ones, distinct from the all-zeros and omitted cases",
                     "my_id": 0,
                     "ids": [0],
@@ -508,7 +474,7 @@
                     ]
                 },
                 {
-                    "tc_id": 28,
+                    "tc_id": 26,
                     "comment": "All signers participate, signed by a non-first member of the signer set",
                     "my_id": 1,
                     "ids": [0, 1, 2],
@@ -525,7 +491,7 @@
                     ]
                 },
                 {
-                    "tc_id": 29,
+                    "tc_id": 27,
                     "comment": "Empty message",
                     "my_id": 0,
                     "ids": [0],
@@ -542,7 +508,7 @@
                     ]
                 },
                 {
-                    "tc_id": 30,
+                    "tc_id": 28,
                     "comment": "Non-standard message length (38 bytes)",
                     "my_id": 0,
                     "ids": [0],
@@ -559,7 +525,7 @@
                     ]
                 },
                 {
-                    "tc_id": 31,
+                    "tc_id": 29,
                     "comment": "Single x-only tweak applied",
                     "my_id": 0,
                     "ids": [0],
@@ -580,13 +546,13 @@
             ],
             "error_tests": [
                 {
-                    "tc_id": 32,
+                    "tc_id": 30,
                     "comment": "Signer's identifier is absent from the signer set",
                     "my_id": 1,
                     "ids": [0],
                     "pubshare_indices": [0],
                     "secshare_index": 0,
-                    "aggothernonce": null,
+                    "aggothernonce": "03BF06149B3E614403EA899F37446B294117785D15D238E1E36989F294120200A20329620EA331F70450B94A7F6B175CF7C5A65CD967D367332AFD4C6FE514882467",
                     "rand": "0000000000000000000000000000000000000000000000000000000000000000",
                     "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
                     "tweaks": [],
@@ -597,7 +563,7 @@
                     }
                 },
                 {
-                    "tc_id": 33,
+                    "tc_id": 31,
                     "comment": "Signer set contains a duplicate id",
                     "my_id": 0,
                     "ids": [0, 1, 1],
@@ -614,7 +580,7 @@
                     }
                 },
                 {
-                    "tc_id": 34,
+                    "tc_id": 32,
                     "comment": "A public share is not a valid point",
                     "my_id": 0,
                     "ids": [0, 1],
@@ -631,13 +597,13 @@
                     }
                 },
                 {
-                    "tc_id": 35,
+                    "tc_id": 33,
                     "comment": "A signer id is outside the valid range [0, n-1]",
                     "my_id": 0,
                     "ids": [3],
                     "pubshare_indices": [0],
                     "secshare_index": 0,
-                    "aggothernonce": null,
+                    "aggothernonce": "03B19C94C4B6537008FFF018971B311BF30B1BAB5F8983A5B262D0CD37CBD309200329A028ADEF6AB30E667123E82DFB1BB055F380D0CDD5CDBF4ADCB1067398F558",
                     "rand": "0000000000000000000000000000000000000000000000000000000000000000",
                     "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
                     "tweaks": [],
@@ -648,7 +614,7 @@
                     }
                 },
                 {
-                    "tc_id": 36,
+                    "tc_id": 34,
                     "comment": "Aggregate of the other signers' nonces is invalid: first half has an unknown tag 0x04",
                     "my_id": 0,
                     "ids": [0, 1],
@@ -666,7 +632,7 @@
                     }
                 },
                 {
-                    "tc_id": 37,
+                    "tc_id": 35,
                     "comment": "Aggregate of the other signers' nonces is invalid: first half is all zeros",
                     "my_id": 0,
                     "ids": [0, 1],
@@ -684,7 +650,7 @@
                     }
                 },
                 {
-                    "tc_id": 38,
+                    "tc_id": 36,
                     "comment": "Aggregate of the other signers' nonces is invalid: second half is not a point on the curve",
                     "my_id": 0,
                     "ids": [0, 1],
@@ -702,7 +668,7 @@
                     }
                 },
                 {
-                    "tc_id": 39,
+                    "tc_id": 37,
                     "comment": "Aggregate of the other signers' nonces is invalid: second half's x-coordinate exceeds the field size",
                     "my_id": 0,
                     "ids": [0, 1],
@@ -720,7 +686,7 @@
                     }
                 },
                 {
-                    "tc_id": 40,
+                    "tc_id": 38,
                     "comment": "Tweak exceeds the group order",
                     "my_id": 0,
                     "ids": [0],
@@ -739,7 +705,7 @@
                     }
                 },
                 {
-                    "tc_id": 41,
+                    "tc_id": 39,
                     "comment": "Fewer signers than the threshold t",
                     "my_id": 0,
                     "ids": [],
@@ -756,7 +722,7 @@
                     }
                 },
                 {
-                    "tc_id": 42,
+                    "tc_id": 40,
                     "comment": "Secret share is out of range (zero)",
                     "my_id": 0,
                     "ids": [0],
@@ -793,7 +759,7 @@
             ],
             "valid_tests": [
                 {
-                    "tc_id": 43,
+                    "tc_id": 41,
                     "comment": "Minimum threshold subset of signers",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -810,7 +776,7 @@
                     ]
                 },
                 {
-                    "tc_id": 44,
+                    "tc_id": 42,
                     "comment": "Reordering the signer set leaves the deterministic output unchanged, because the identifiers are sorted before they are bound into the nonce derivation and the binding value",
                     "my_id": 0,
                     "ids": [2, 1, 0],
@@ -827,7 +793,7 @@
                     ]
                 },
                 {
-                    "tc_id": 45,
+                    "tc_id": 43,
                     "comment": "Auxiliary randomness omitted (null), which is not equivalent to all-zeros randomness",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -844,7 +810,7 @@
                     ]
                 },
                 {
-                    "tc_id": 46,
+                    "tc_id": 44,
                     "comment": "Auxiliary randomness is all ones, distinct from the all-zeros and omitted cases",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -861,7 +827,7 @@
                     ]
                 },
                 {
-                    "tc_id": 47,
+                    "tc_id": 45,
                     "comment": "All signers participate, signed by a non-first member of the signer set",
                     "my_id": 1,
                     "ids": [0, 1, 2],
@@ -878,7 +844,7 @@
                     ]
                 },
                 {
-                    "tc_id": 48,
+                    "tc_id": 46,
                     "comment": "Empty message",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -895,7 +861,7 @@
                     ]
                 },
                 {
-                    "tc_id": 49,
+                    "tc_id": 47,
                     "comment": "Non-standard message length (38 bytes)",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -912,7 +878,7 @@
                     ]
                 },
                 {
-                    "tc_id": 50,
+                    "tc_id": 48,
                     "comment": "Single x-only tweak applied",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -933,7 +899,7 @@
             ],
             "error_tests": [
                 {
-                    "tc_id": 51,
+                    "tc_id": 49,
                     "comment": "Signer set contains a duplicate id",
                     "my_id": 0,
                     "ids": [0, 1, 1],
@@ -950,7 +916,7 @@
                     }
                 },
                 {
-                    "tc_id": 52,
+                    "tc_id": 50,
                     "comment": "A public share is not a valid point",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -967,7 +933,7 @@
                     }
                 },
                 {
-                    "tc_id": 53,
+                    "tc_id": 51,
                     "comment": "A signer id is outside the valid range [0, n-1]",
                     "my_id": 1,
                     "ids": [3, 1, 2],
@@ -984,7 +950,7 @@
                     }
                 },
                 {
-                    "tc_id": 54,
+                    "tc_id": 52,
                     "comment": "Signer set's public shares do not match the threshold public key",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1001,7 +967,7 @@
                     }
                 },
                 {
-                    "tc_id": 55,
+                    "tc_id": 53,
                     "comment": "Aggregate of the other signers' nonces is invalid: first half has an unknown tag 0x04",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1019,7 +985,7 @@
                     }
                 },
                 {
-                    "tc_id": 56,
+                    "tc_id": 54,
                     "comment": "Aggregate of the other signers' nonces is invalid: first half is all zeros",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1037,7 +1003,7 @@
                     }
                 },
                 {
-                    "tc_id": 57,
+                    "tc_id": 55,
                     "comment": "Aggregate of the other signers' nonces is invalid: second half is not a point on the curve",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1055,7 +1021,7 @@
                     }
                 },
                 {
-                    "tc_id": 58,
+                    "tc_id": 56,
                     "comment": "Aggregate of the other signers' nonces is invalid: second half's x-coordinate exceeds the field size",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1073,7 +1039,7 @@
                     }
                 },
                 {
-                    "tc_id": 59,
+                    "tc_id": 57,
                     "comment": "Tweak exceeds the group order",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1092,7 +1058,7 @@
                     }
                 },
                 {
-                    "tc_id": 60,
+                    "tc_id": 58,
                     "comment": "Fewer signers than the threshold t",
                     "my_id": 0,
                     "ids": [0, 1],
@@ -1109,7 +1075,7 @@
                     }
                 },
                 {
-                    "tc_id": 61,
+                    "tc_id": 59,
                     "comment": "Secret share is out of range (zero)",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1150,7 +1116,7 @@
             ],
             "valid_tests": [
                 {
-                    "tc_id": 62,
+                    "tc_id": 60,
                     "comment": "Minimum threshold subset of signers",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1167,7 +1133,7 @@
                     ]
                 },
                 {
-                    "tc_id": 63,
+                    "tc_id": 61,
                     "comment": "Reordering the signer set leaves the deterministic output unchanged, because the identifiers are sorted before they are bound into the nonce derivation and the binding value",
                     "my_id": 0,
                     "ids": [2, 1, 0],
@@ -1184,7 +1150,7 @@
                     ]
                 },
                 {
-                    "tc_id": 64,
+                    "tc_id": 62,
                     "comment": "A different threshold subset gives a different deterministic nonce, since the signer set is bound into the nonce derivation",
                     "my_id": 0,
                     "ids": [0, 3, 4],
@@ -1201,7 +1167,7 @@
                     ]
                 },
                 {
-                    "tc_id": 65,
+                    "tc_id": 63,
                     "comment": "Auxiliary randomness omitted (null), which is not equivalent to all-zeros randomness",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1218,7 +1184,7 @@
                     ]
                 },
                 {
-                    "tc_id": 66,
+                    "tc_id": 64,
                     "comment": "Auxiliary randomness is all ones, distinct from the all-zeros and omitted cases",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1235,7 +1201,7 @@
                     ]
                 },
                 {
-                    "tc_id": 67,
+                    "tc_id": 65,
                     "comment": "All signers participate, signed by a non-first member of the signer set",
                     "my_id": 1,
                     "ids": [0, 1, 2, 3, 4],
@@ -1252,7 +1218,7 @@
                     ]
                 },
                 {
-                    "tc_id": 68,
+                    "tc_id": 66,
                     "comment": "Empty message",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1269,7 +1235,7 @@
                     ]
                 },
                 {
-                    "tc_id": 69,
+                    "tc_id": 67,
                     "comment": "Non-standard message length (38 bytes)",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1286,7 +1252,7 @@
                     ]
                 },
                 {
-                    "tc_id": 70,
+                    "tc_id": 68,
                     "comment": "Single x-only tweak applied",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1307,7 +1273,7 @@
             ],
             "error_tests": [
                 {
-                    "tc_id": 71,
+                    "tc_id": 69,
                     "comment": "Signer's identifier is absent from the signer set",
                     "my_id": 3,
                     "ids": [0, 1, 2],
@@ -1324,7 +1290,7 @@
                     }
                 },
                 {
-                    "tc_id": 72,
+                    "tc_id": 70,
                     "comment": "Signer set contains a duplicate id",
                     "my_id": 0,
                     "ids": [0, 1, 1],
@@ -1341,7 +1307,7 @@
                     }
                 },
                 {
-                    "tc_id": 73,
+                    "tc_id": 71,
                     "comment": "Signer's public share is not in the public share list",
                     "my_id": 1,
                     "ids": [1, 2, 3],
@@ -1358,7 +1324,7 @@
                     }
                 },
                 {
-                    "tc_id": 74,
+                    "tc_id": 72,
                     "comment": "A public share is not a valid point",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1375,7 +1341,7 @@
                     }
                 },
                 {
-                    "tc_id": 75,
+                    "tc_id": 73,
                     "comment": "A signer id is outside the valid range [0, n-1]",
                     "my_id": 1,
                     "ids": [5, 1, 2],
@@ -1392,7 +1358,7 @@
                     }
                 },
                 {
-                    "tc_id": 76,
+                    "tc_id": 74,
                     "comment": "Signer set's public shares do not match the threshold public key",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1409,7 +1375,7 @@
                     }
                 },
                 {
-                    "tc_id": 77,
+                    "tc_id": 75,
                     "comment": "Aggregate of the other signers' nonces is invalid: first half has an unknown tag 0x04",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1427,7 +1393,7 @@
                     }
                 },
                 {
-                    "tc_id": 78,
+                    "tc_id": 76,
                     "comment": "Aggregate of the other signers' nonces is invalid: first half is all zeros",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1445,7 +1411,7 @@
                     }
                 },
                 {
-                    "tc_id": 79,
+                    "tc_id": 77,
                     "comment": "Aggregate of the other signers' nonces is invalid: second half is not a point on the curve",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1463,7 +1429,7 @@
                     }
                 },
                 {
-                    "tc_id": 80,
+                    "tc_id": 78,
                     "comment": "Aggregate of the other signers' nonces is invalid: second half's x-coordinate exceeds the field size",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1481,7 +1447,7 @@
                     }
                 },
                 {
-                    "tc_id": 81,
+                    "tc_id": 79,
                     "comment": "Tweak exceeds the group order",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1500,7 +1466,7 @@
                     }
                 },
                 {
-                    "tc_id": 82,
+                    "tc_id": 80,
                     "comment": "Fewer signers than the threshold t",
                     "my_id": 0,
                     "ids": [0, 1],
@@ -1517,7 +1483,7 @@
                     }
                 },
                 {
-                    "tc_id": 83,
+                    "tc_id": 81,
                     "comment": "Secret share is out of range (zero)",
                     "my_id": 0,
                     "ids": [0, 1, 2],

--- a/python/vectors/det_sign_vectors.json
+++ b/python/vectors/det_sign_vectors.json
@@ -177,7 +177,7 @@
             "error_tests": [
                 {
                     "tc_id": 10,
-                    "comment": "my_id is not in the signer set",
+                    "comment": "Signer's identifier is absent from the signer set",
                     "my_id": 2,
                     "ids": [0, 1],
                     "pubshare_indices": [0, 1],
@@ -245,6 +245,23 @@
                 },
                 {
                     "tc_id": 14,
+                    "comment": "A signer id is outside the valid range [0, n-1]",
+                    "my_id": 1,
+                    "ids": [3, 1],
+                    "pubshare_indices": [0, 1],
+                    "secshare_index": 1,
+                    "aggothernonce": "033F6252CADE1AB642BC9BF9D3CC15277A873D6CF56549F44D35B50FE15C00C24E02212B5210943685530220501404DF3BD891C264E4DEF990F33787EA6630BC2AFC",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The participant identifier at index 0 is out of range."
+                    }
+                },
+                {
+                    "tc_id": 15,
                     "comment": "Signer set's public shares do not match the threshold public key",
                     "my_id": 0,
                     "ids": [0, 1],
@@ -261,7 +278,7 @@
                     }
                 },
                 {
-                    "tc_id": 15,
+                    "tc_id": 16,
                     "comment": "Aggregate of the other signers' nonces is invalid: first half has an unknown tag 0x04",
                     "my_id": 0,
                     "ids": [0, 1],
@@ -279,7 +296,7 @@
                     }
                 },
                 {
-                    "tc_id": 16,
+                    "tc_id": 17,
                     "comment": "Aggregate of the other signers' nonces is invalid: first half is all zeros",
                     "my_id": 0,
                     "ids": [0, 1],
@@ -297,7 +314,7 @@
                     }
                 },
                 {
-                    "tc_id": 17,
+                    "tc_id": 18,
                     "comment": "Aggregate of the other signers' nonces is invalid: second half is not a point on the curve",
                     "my_id": 0,
                     "ids": [0, 1],
@@ -315,7 +332,7 @@
                     }
                 },
                 {
-                    "tc_id": 18,
+                    "tc_id": 19,
                     "comment": "Aggregate of the other signers' nonces is invalid: second half's x-coordinate exceeds the field size",
                     "my_id": 0,
                     "ids": [0, 1],
@@ -333,7 +350,7 @@
                     }
                 },
                 {
-                    "tc_id": 19,
+                    "tc_id": 20,
                     "comment": "Tweak exceeds the group order",
                     "my_id": 0,
                     "ids": [0, 1],
@@ -352,7 +369,24 @@
                     }
                 },
                 {
-                    "tc_id": 20,
+                    "tc_id": 21,
+                    "comment": "Fewer signers than the threshold t",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "aggothernonce": null,
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The number of signers must be between t and n."
+                    }
+                },
+                {
+                    "tc_id": 22,
                     "comment": "Secret share is out of range (zero)",
                     "my_id": 0,
                     "ids": [0, 1],
@@ -389,7 +423,7 @@
             ],
             "valid_tests": [
                 {
-                    "tc_id": 21,
+                    "tc_id": 23,
                     "comment": "Minimum threshold subset of signers",
                     "my_id": 0,
                     "ids": [0],
@@ -406,7 +440,7 @@
                     ]
                 },
                 {
-                    "tc_id": 22,
+                    "tc_id": 24,
                     "comment": "Reordering the signer set leaves the deterministic output unchanged, because the identifiers are sorted before they are bound into the nonce derivation and the binding value",
                     "my_id": 0,
                     "ids": [1, 0],
@@ -423,7 +457,7 @@
                     ]
                 },
                 {
-                    "tc_id": 23,
+                    "tc_id": 25,
                     "comment": "A different threshold subset gives a different deterministic nonce, since the signer set is bound into the nonce derivation",
                     "my_id": 1,
                     "ids": [1],
@@ -440,7 +474,7 @@
                     ]
                 },
                 {
-                    "tc_id": 24,
+                    "tc_id": 26,
                     "comment": "Auxiliary randomness omitted (null), which is not equivalent to all-zeros randomness",
                     "my_id": 0,
                     "ids": [0],
@@ -457,7 +491,7 @@
                     ]
                 },
                 {
-                    "tc_id": 25,
+                    "tc_id": 27,
                     "comment": "Auxiliary randomness is all ones, distinct from the all-zeros and omitted cases",
                     "my_id": 0,
                     "ids": [0],
@@ -474,7 +508,7 @@
                     ]
                 },
                 {
-                    "tc_id": 26,
+                    "tc_id": 28,
                     "comment": "All signers participate, signed by a non-first member of the signer set",
                     "my_id": 1,
                     "ids": [0, 1, 2],
@@ -491,7 +525,7 @@
                     ]
                 },
                 {
-                    "tc_id": 27,
+                    "tc_id": 29,
                     "comment": "Empty message",
                     "my_id": 0,
                     "ids": [0],
@@ -508,7 +542,7 @@
                     ]
                 },
                 {
-                    "tc_id": 28,
+                    "tc_id": 30,
                     "comment": "Non-standard message length (38 bytes)",
                     "my_id": 0,
                     "ids": [0],
@@ -525,7 +559,7 @@
                     ]
                 },
                 {
-                    "tc_id": 29,
+                    "tc_id": 31,
                     "comment": "Single x-only tweak applied",
                     "my_id": 0,
                     "ids": [0],
@@ -546,8 +580,8 @@
             ],
             "error_tests": [
                 {
-                    "tc_id": 30,
-                    "comment": "my_id is not in the signer set",
+                    "tc_id": 32,
+                    "comment": "Signer's identifier is absent from the signer set",
                     "my_id": 1,
                     "ids": [0],
                     "pubshare_indices": [0],
@@ -563,7 +597,7 @@
                     }
                 },
                 {
-                    "tc_id": 31,
+                    "tc_id": 33,
                     "comment": "Signer set contains a duplicate id",
                     "my_id": 0,
                     "ids": [0, 1, 1],
@@ -580,7 +614,7 @@
                     }
                 },
                 {
-                    "tc_id": 32,
+                    "tc_id": 34,
                     "comment": "A public share is not a valid point",
                     "my_id": 0,
                     "ids": [0, 1],
@@ -597,7 +631,24 @@
                     }
                 },
                 {
-                    "tc_id": 33,
+                    "tc_id": 35,
+                    "comment": "A signer id is outside the valid range [0, n-1]",
+                    "my_id": 0,
+                    "ids": [3],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "aggothernonce": null,
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The participant identifier at index 0 is out of range."
+                    }
+                },
+                {
+                    "tc_id": 36,
                     "comment": "Aggregate of the other signers' nonces is invalid: first half has an unknown tag 0x04",
                     "my_id": 0,
                     "ids": [0, 1],
@@ -615,7 +666,7 @@
                     }
                 },
                 {
-                    "tc_id": 34,
+                    "tc_id": 37,
                     "comment": "Aggregate of the other signers' nonces is invalid: first half is all zeros",
                     "my_id": 0,
                     "ids": [0, 1],
@@ -633,7 +684,7 @@
                     }
                 },
                 {
-                    "tc_id": 35,
+                    "tc_id": 38,
                     "comment": "Aggregate of the other signers' nonces is invalid: second half is not a point on the curve",
                     "my_id": 0,
                     "ids": [0, 1],
@@ -651,7 +702,7 @@
                     }
                 },
                 {
-                    "tc_id": 36,
+                    "tc_id": 39,
                     "comment": "Aggregate of the other signers' nonces is invalid: second half's x-coordinate exceeds the field size",
                     "my_id": 0,
                     "ids": [0, 1],
@@ -669,7 +720,7 @@
                     }
                 },
                 {
-                    "tc_id": 37,
+                    "tc_id": 40,
                     "comment": "Tweak exceeds the group order",
                     "my_id": 0,
                     "ids": [0],
@@ -688,7 +739,24 @@
                     }
                 },
                 {
-                    "tc_id": 38,
+                    "tc_id": 41,
+                    "comment": "Fewer signers than the threshold t",
+                    "my_id": 0,
+                    "ids": [],
+                    "pubshare_indices": [],
+                    "secshare_index": 0,
+                    "aggothernonce": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The number of signers must be between t and n."
+                    }
+                },
+                {
+                    "tc_id": 42,
                     "comment": "Secret share is out of range (zero)",
                     "my_id": 0,
                     "ids": [0],
@@ -725,7 +793,7 @@
             ],
             "valid_tests": [
                 {
-                    "tc_id": 39,
+                    "tc_id": 43,
                     "comment": "Minimum threshold subset of signers",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -742,7 +810,7 @@
                     ]
                 },
                 {
-                    "tc_id": 40,
+                    "tc_id": 44,
                     "comment": "Reordering the signer set leaves the deterministic output unchanged, because the identifiers are sorted before they are bound into the nonce derivation and the binding value",
                     "my_id": 0,
                     "ids": [2, 1, 0],
@@ -759,7 +827,7 @@
                     ]
                 },
                 {
-                    "tc_id": 41,
+                    "tc_id": 45,
                     "comment": "Auxiliary randomness omitted (null), which is not equivalent to all-zeros randomness",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -776,7 +844,7 @@
                     ]
                 },
                 {
-                    "tc_id": 42,
+                    "tc_id": 46,
                     "comment": "Auxiliary randomness is all ones, distinct from the all-zeros and omitted cases",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -793,7 +861,7 @@
                     ]
                 },
                 {
-                    "tc_id": 43,
+                    "tc_id": 47,
                     "comment": "All signers participate, signed by a non-first member of the signer set",
                     "my_id": 1,
                     "ids": [0, 1, 2],
@@ -810,7 +878,7 @@
                     ]
                 },
                 {
-                    "tc_id": 44,
+                    "tc_id": 48,
                     "comment": "Empty message",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -827,7 +895,7 @@
                     ]
                 },
                 {
-                    "tc_id": 45,
+                    "tc_id": 49,
                     "comment": "Non-standard message length (38 bytes)",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -844,7 +912,7 @@
                     ]
                 },
                 {
-                    "tc_id": 46,
+                    "tc_id": 50,
                     "comment": "Single x-only tweak applied",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -865,7 +933,7 @@
             ],
             "error_tests": [
                 {
-                    "tc_id": 47,
+                    "tc_id": 51,
                     "comment": "Signer set contains a duplicate id",
                     "my_id": 0,
                     "ids": [0, 1, 1],
@@ -882,7 +950,7 @@
                     }
                 },
                 {
-                    "tc_id": 48,
+                    "tc_id": 52,
                     "comment": "A public share is not a valid point",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -899,7 +967,24 @@
                     }
                 },
                 {
-                    "tc_id": 49,
+                    "tc_id": 53,
+                    "comment": "A signer id is outside the valid range [0, n-1]",
+                    "my_id": 1,
+                    "ids": [3, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 1,
+                    "aggothernonce": "037FF9B8D69E033F05484D8B6F3F1254528765850218BE9D6D438864D61D8794C6029DEB098F8FD67D8C006D686A642176B7E560CBD6F1356E454A5E93B2CE659609",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The participant identifier at index 0 is out of range."
+                    }
+                },
+                {
+                    "tc_id": 54,
                     "comment": "Signer set's public shares do not match the threshold public key",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -916,7 +1001,7 @@
                     }
                 },
                 {
-                    "tc_id": 50,
+                    "tc_id": 55,
                     "comment": "Aggregate of the other signers' nonces is invalid: first half has an unknown tag 0x04",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -934,7 +1019,7 @@
                     }
                 },
                 {
-                    "tc_id": 51,
+                    "tc_id": 56,
                     "comment": "Aggregate of the other signers' nonces is invalid: first half is all zeros",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -952,7 +1037,7 @@
                     }
                 },
                 {
-                    "tc_id": 52,
+                    "tc_id": 57,
                     "comment": "Aggregate of the other signers' nonces is invalid: second half is not a point on the curve",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -970,7 +1055,7 @@
                     }
                 },
                 {
-                    "tc_id": 53,
+                    "tc_id": 58,
                     "comment": "Aggregate of the other signers' nonces is invalid: second half's x-coordinate exceeds the field size",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -988,7 +1073,7 @@
                     }
                 },
                 {
-                    "tc_id": 54,
+                    "tc_id": 59,
                     "comment": "Tweak exceeds the group order",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1007,7 +1092,24 @@
                     }
                 },
                 {
-                    "tc_id": 55,
+                    "tc_id": 60,
+                    "comment": "Fewer signers than the threshold t",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "secshare_index": 0,
+                    "aggothernonce": "02EF352923D0B4768732A380315C00960A71DA1FAB06D7CF3B440385084E3FAC2F02141328A420CA7916711CC3B40981B9342377FC75FB8FEF29D4D3BC71148A4082",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The number of signers must be between t and n."
+                    }
+                },
+                {
+                    "tc_id": 61,
                     "comment": "Secret share is out of range (zero)",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1048,7 +1150,7 @@
             ],
             "valid_tests": [
                 {
-                    "tc_id": 56,
+                    "tc_id": 62,
                     "comment": "Minimum threshold subset of signers",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1065,7 +1167,7 @@
                     ]
                 },
                 {
-                    "tc_id": 57,
+                    "tc_id": 63,
                     "comment": "Reordering the signer set leaves the deterministic output unchanged, because the identifiers are sorted before they are bound into the nonce derivation and the binding value",
                     "my_id": 0,
                     "ids": [2, 1, 0],
@@ -1082,7 +1184,7 @@
                     ]
                 },
                 {
-                    "tc_id": 58,
+                    "tc_id": 64,
                     "comment": "A different threshold subset gives a different deterministic nonce, since the signer set is bound into the nonce derivation",
                     "my_id": 0,
                     "ids": [0, 3, 4],
@@ -1099,7 +1201,7 @@
                     ]
                 },
                 {
-                    "tc_id": 59,
+                    "tc_id": 65,
                     "comment": "Auxiliary randomness omitted (null), which is not equivalent to all-zeros randomness",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1116,7 +1218,7 @@
                     ]
                 },
                 {
-                    "tc_id": 60,
+                    "tc_id": 66,
                     "comment": "Auxiliary randomness is all ones, distinct from the all-zeros and omitted cases",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1133,7 +1235,7 @@
                     ]
                 },
                 {
-                    "tc_id": 61,
+                    "tc_id": 67,
                     "comment": "All signers participate, signed by a non-first member of the signer set",
                     "my_id": 1,
                     "ids": [0, 1, 2, 3, 4],
@@ -1150,7 +1252,7 @@
                     ]
                 },
                 {
-                    "tc_id": 62,
+                    "tc_id": 68,
                     "comment": "Empty message",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1167,7 +1269,7 @@
                     ]
                 },
                 {
-                    "tc_id": 63,
+                    "tc_id": 69,
                     "comment": "Non-standard message length (38 bytes)",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1184,7 +1286,7 @@
                     ]
                 },
                 {
-                    "tc_id": 64,
+                    "tc_id": 70,
                     "comment": "Single x-only tweak applied",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1205,8 +1307,8 @@
             ],
             "error_tests": [
                 {
-                    "tc_id": 65,
-                    "comment": "my_id is not in the signer set",
+                    "tc_id": 71,
+                    "comment": "Signer's identifier is absent from the signer set",
                     "my_id": 3,
                     "ids": [0, 1, 2],
                     "pubshare_indices": [0, 1, 2],
@@ -1222,7 +1324,7 @@
                     }
                 },
                 {
-                    "tc_id": 66,
+                    "tc_id": 72,
                     "comment": "Signer set contains a duplicate id",
                     "my_id": 0,
                     "ids": [0, 1, 1],
@@ -1239,7 +1341,7 @@
                     }
                 },
                 {
-                    "tc_id": 67,
+                    "tc_id": 73,
                     "comment": "Signer's public share is not in the public share list",
                     "my_id": 1,
                     "ids": [1, 2, 3],
@@ -1256,7 +1358,7 @@
                     }
                 },
                 {
-                    "tc_id": 68,
+                    "tc_id": 74,
                     "comment": "A public share is not a valid point",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1273,7 +1375,24 @@
                     }
                 },
                 {
-                    "tc_id": 69,
+                    "tc_id": 75,
+                    "comment": "A signer id is outside the valid range [0, n-1]",
+                    "my_id": 1,
+                    "ids": [5, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 1,
+                    "aggothernonce": "035CDD6D2363EA4AE8D2EB92A78B3B9E741DEA0654DD220706B1A05664E6B4F7FE02C9F9FA0982818E3FE755F78D740A8A07FE1FB5A0CF253389A75533ED6A036486",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The participant identifier at index 0 is out of range."
+                    }
+                },
+                {
+                    "tc_id": 76,
                     "comment": "Signer set's public shares do not match the threshold public key",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1290,7 +1409,7 @@
                     }
                 },
                 {
-                    "tc_id": 70,
+                    "tc_id": 77,
                     "comment": "Aggregate of the other signers' nonces is invalid: first half has an unknown tag 0x04",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1308,7 +1427,7 @@
                     }
                 },
                 {
-                    "tc_id": 71,
+                    "tc_id": 78,
                     "comment": "Aggregate of the other signers' nonces is invalid: first half is all zeros",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1326,7 +1445,7 @@
                     }
                 },
                 {
-                    "tc_id": 72,
+                    "tc_id": 79,
                     "comment": "Aggregate of the other signers' nonces is invalid: second half is not a point on the curve",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1344,7 +1463,7 @@
                     }
                 },
                 {
-                    "tc_id": 73,
+                    "tc_id": 80,
                     "comment": "Aggregate of the other signers' nonces is invalid: second half's x-coordinate exceeds the field size",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1362,7 +1481,7 @@
                     }
                 },
                 {
-                    "tc_id": 74,
+                    "tc_id": 81,
                     "comment": "Tweak exceeds the group order",
                     "my_id": 0,
                     "ids": [0, 1, 2],
@@ -1381,7 +1500,24 @@
                     }
                 },
                 {
-                    "tc_id": 75,
+                    "tc_id": 82,
+                    "comment": "Fewer signers than the threshold t",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "secshare_index": 0,
+                    "aggothernonce": "02DC0CD5CAC6A1EDFF9AFE93C22F1A86189BD5493DD8735A0981C00FFB267D00750300CA727FCD503E732E37567B12A27DFBE5440B8240B03848FFF55F14168AE397",
+                    "rand": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweaks": [],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The number of signers must be between t and n."
+                    }
+                },
+                {
+                    "tc_id": 83,
                     "comment": "Secret share is out of range (zero)",
                     "my_id": 0,
                     "ids": [0, 1, 2],

--- a/python/vectors/sig_agg_vectors.json
+++ b/python/vectors/sig_agg_vectors.json
@@ -19,7 +19,7 @@
             "valid_tests": [
                 {
                     "tc_id": 1,
-                    "comment": "Minimum threshold subset of signers (t=2 of n=3), no tweaks",
+                    "comment": "Minimum threshold subset of signers, no tweaks",
                     "ids": [0, 1],
                     "pubshare_indices": [0, 1],
                     "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",

--- a/python/vectors/sig_agg_vectors.json
+++ b/python/vectors/sig_agg_vectors.json
@@ -64,7 +64,7 @@
                 },
                 {
                     "tc_id": 4,
-                    "comment": "All n=3 signers participate, no tweaks",
+                    "comment": "All signers participate, no tweaks",
                     "ids": [0, 1, 2],
                     "pubshare_indices": [0, 1, 2],
                     "aggnonce": "02CBC2E41AF87290A1401D49927FC30D7F40A404C4DF3E5FC734014188DBC44E1503C15312EDC691EB213F3B8AAC195D251A390563CD5E313D738A89DAEB4DA80746",
@@ -109,6 +109,338 @@
                     "is_xonly": [],
                     "psigs": [
                         "2B69442F9BCE21BB722831A2150FB9A6DF6D0288D39E2E4F5687E92A3C4A7862"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The psigs and ids arrays must have the same length."
+                    }
+                }
+            ]
+        },
+        {
+            "tg_id": "1of3",
+            "t": 1,
+            "n": 3,
+            "thresh_pk": "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F",
+            "pubshares": [
+                "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F",
+                "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F",
+                "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F"
+            ],
+            "tweaks": [
+                "E8F791FF9225A2AF0102AFFF4A9A723D9612A682A25EBE79802B263CDFCD83BB",
+                "AE2EA797CC0FE72AC5B97B97F3C6957D7E4199A167A58EB08BCAFFDA70AC0455",
+                "F52ECBC565B3D8BEA2DFD5B75A4F457E54369809322E4120831626F290FA87E0",
+                "1969AD73CC177FA0B4FCED6DF1F7BF9907E665FDE9BA196A74FED0A3CF5AEF9D"
+            ],
+            "valid_tests": [
+                {
+                    "tc_id": 7,
+                    "comment": "Minimum threshold subset of signers, no tweaks",
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "0662F783275AEB48C647E93D941AD63AF0A53F05C31C19153D203D68DAFF2831"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "468943B2324187A2B2F2082F562C9E5AEA55C5748DFB382EED749840BB9932FA0662F783275AEB48C647E93D941AD63AF0A53F05C31C19153D203D68DAFF2831"
+                },
+                {
+                    "tc_id": 8,
+                    "comment": "Aggregation with three tweaks applied (one x-only, two plain)",
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "tweak_indices": [0, 1, 2],
+                    "is_xonly": [true, false, false],
+                    "psigs": [
+                        "D4491BC20826CA2931DABD4AC57D6DA8278C0CCBE419F2EB60B25E21FB855005"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "985E99395C9FD967DD5DF5E6D61A7B60861A1DD5ED2A6AF8BC39AE79E008E6350C23C09A38908FFB710037CB937D723F15128CB7A9CBAF6A54B57754F21EADD1"
+                },
+                {
+                    "tc_id": 9,
+                    "comment": "All signers participate, no tweaks",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "aggnonce": "0277E716756BAEFD922DCD339D083FEB1C0263B06999328492331FB876A225EEA3033910C4FC151C7AA914B4D2AC97B3F09C56A36A5F95F14043D90210CC1FCD4245",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "98880D6A53460E57168FB517431D65569AE9AEE791796959E21E4EDF4BE8F8C8",
+                        "010D7844DBD7DCDE861BA2DEAEBF1EDB620446760857FC88A18C3735496F1306",
+                        "6609DBB32B76A8843BBE59AF11A8A32D87F28C170E6E451421ED9C514B15AC32"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "96EB76FDD08FB48B41A6674F5008427F6E3EC1D105D634411BF83A9405DBA393FF9F61625A9493B9D869B1A50385275F84E08174A83FAAF6A5982265E06DB800"
+                }
+            ],
+            "error_tests": [
+                {
+                    "tc_id": 10,
+                    "comment": "Partial signature equals the group order, which is out of range",
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": 0,
+                        "contrib": "psig"
+                    }
+                },
+                {
+                    "tc_id": 11,
+                    "comment": "Number of partial signatures does not match the number of signers",
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The psigs and ids arrays must have the same length."
+                    }
+                }
+            ]
+        },
+        {
+            "tg_id": "3of3",
+            "t": 3,
+            "n": 3,
+            "thresh_pk": "023E94D6A68620D3F60221A4186786274A711221A8BBB31A5388DFA6718E8EF7BB",
+            "pubshares": [
+                "03A3E932BA9DD0063D721590B6EF21DD4566A97B203343FDE9DA5815DB9BE049CA",
+                "0201E5FEAC0DB5059C32B045F37799101A96262B3C88CE85D610451FC21A0457FF",
+                "03EF72D10D1DFE4E786619536A458507CAF105FCCDB8173DAF2E358054AF2FA4A2"
+            ],
+            "tweaks": [
+                "E8F791FF9225A2AF0102AFFF4A9A723D9612A682A25EBE79802B263CDFCD83BB",
+                "AE2EA797CC0FE72AC5B97B97F3C6957D7E4199A167A58EB08BCAFFDA70AC0455",
+                "F52ECBC565B3D8BEA2DFD5B75A4F457E54369809322E4120831626F290FA87E0",
+                "1969AD73CC177FA0B4FCED6DF1F7BF9907E665FDE9BA196A74FED0A3CF5AEF9D"
+            ],
+            "valid_tests": [
+                {
+                    "tc_id": 12,
+                    "comment": "Minimum threshold subset of signers, no tweaks",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "08A866ABF049F70B7D842680EDB78C1C742D0368090B9F579CBE9D7019F53A8D",
+                        "6D180D3D1776FC298E1F00F806D8444EA597749245ED88E05B0FF08C98AA6316",
+                        "E13827F0D8317FB4E178BFA453147B35C51F797E1FE0A23AAF701341E264E977"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "A644B6E81BFF3C477C33B99F71839845267BA37A933F178E78059D44D6A8151656F89BD9DFF272E9ED1BE71D47A44BA224351491BF912A36E76C42B1C4CE45D9"
+                },
+                {
+                    "tc_id": 13,
+                    "comment": "Reordering the signer set leaves the aggregate signature unchanged, because the partial signatures are summed and the identifiers are sorted before they are bound into the binding value",
+                    "ids": [2, 1, 0],
+                    "pubshare_indices": [2, 1, 0],
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "E13827F0D8317FB4E178BFA453147B35C51F797E1FE0A23AAF701341E264E977",
+                        "6D180D3D1776FC298E1F00F806D8444EA597749245ED88E05B0FF08C98AA6316",
+                        "08A866ABF049F70B7D842680EDB78C1C742D0368090B9F579CBE9D7019F53A8D"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "A644B6E81BFF3C477C33B99F71839845267BA37A933F178E78059D44D6A8151656F89BD9DFF272E9ED1BE71D47A44BA224351491BF912A36E76C42B1C4CE45D9"
+                },
+                {
+                    "tc_id": 14,
+                    "comment": "Aggregation with three tweaks applied (one x-only, two plain)",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "tweak_indices": [0, 1, 2],
+                    "is_xonly": [true, false, false],
+                    "psigs": [
+                        "D34E4B9813BB91338AE7AAF3E18AB30C72576AB8F384AF7815FBCBF9C1896198",
+                        "6F4E87BCE8A96D88751BD9197218B9F1F19078413D887932762719085CC4C89B",
+                        "3BC22B9A3CB0905FC1CD4DA9C1D455687A7EE92BB0445B1DBF4EF61E03D3F712"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "BECBF4B59D2E628FC146D74BDFF7FA0F17723366AE0768E72428AC8747F50C7763003C708F483162BBD57EC6528C15E23CD1C6CE9A6569C2D21702E5F9AEE10A"
+                }
+            ],
+            "error_tests": [
+                {
+                    "tc_id": 15,
+                    "comment": "Partial signature equals the group order, which is out of range",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "08A866ABF049F70B7D842680EDB78C1C742D0368090B9F579CBE9D7019F53A8D",
+                        "6D180D3D1776FC298E1F00F806D8444EA597749245ED88E05B0FF08C98AA6316",
+                        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": 2,
+                        "contrib": "psig"
+                    }
+                },
+                {
+                    "tc_id": 16,
+                    "comment": "Number of partial signatures does not match the number of signers",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "08A866ABF049F70B7D842680EDB78C1C742D0368090B9F579CBE9D7019F53A8D",
+                        "6D180D3D1776FC298E1F00F806D8444EA597749245ED88E05B0FF08C98AA6316"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The psigs and ids arrays must have the same length."
+                    }
+                }
+            ]
+        },
+        {
+            "tg_id": "3of5",
+            "t": 3,
+            "n": 5,
+            "thresh_pk": "03E1AEA00A7B8D0E0393664FEBBD31569A02CAF223D9AD83E90331DC18B1987358",
+            "pubshares": [
+                "02F333EDD2B6F532C2EF6C42E803B633A42289D0567A75C50EB1C8CF85EC480E8F",
+                "025322F63602ECCF146541B7C9EE4D1FCB84EC139471420472182AE968676A387F",
+                "0230639CEC0A83982E176D6905CE0620FDC57E151565A39D0E0821B8E753AE85B0",
+                "026E1A50E672FEDD3F3C378D6121E5702B050669DBC241D2C2299880152CD207BD",
+                "02DC06C4CA919DE70B4B8281901CCF9471AB91FBFBEE1A8C570D83911CAAF9E2FA"
+            ],
+            "tweaks": [
+                "E8F791FF9225A2AF0102AFFF4A9A723D9612A682A25EBE79802B263CDFCD83BB",
+                "AE2EA797CC0FE72AC5B97B97F3C6957D7E4199A167A58EB08BCAFFDA70AC0455",
+                "F52ECBC565B3D8BEA2DFD5B75A4F457E54369809322E4120831626F290FA87E0",
+                "1969AD73CC177FA0B4FCED6DF1F7BF9907E665FDE9BA196A74FED0A3CF5AEF9D"
+            ],
+            "valid_tests": [
+                {
+                    "tc_id": 17,
+                    "comment": "Minimum threshold subset of signers, no tweaks",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "96630BAD23F362F641D8B88D89F006B2BB3EC7390D80743997ECFC9C96A13AD3",
+                        "2EA9B38288385D6AB64FAEDC74ADF407BA7FF74926E85A10A3B3A6B45C98BD6D",
+                        "AC075489568998C47504EC8E4FC7AB5B243AF7739111DC6ECFF63276F924AE65"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "BC26C0D0B29D2A416C44D04BCFA9D38C835E4D2D18C2E9BF0AC04635044CBF46711413B902B559256D2D53F84E65A616DF4AD90F16320A7D4BC4773B1C286564"
+                },
+                {
+                    "tc_id": 18,
+                    "comment": "Reordering the signer set leaves the aggregate signature unchanged, because the partial signatures are summed and the identifiers are sorted before they are bound into the binding value",
+                    "ids": [2, 1, 0],
+                    "pubshare_indices": [2, 1, 0],
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "AC075489568998C47504EC8E4FC7AB5B243AF7739111DC6ECFF63276F924AE65",
+                        "2EA9B38288385D6AB64FAEDC74ADF407BA7FF74926E85A10A3B3A6B45C98BD6D",
+                        "96630BAD23F362F641D8B88D89F006B2BB3EC7390D80743997ECFC9C96A13AD3"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "BC26C0D0B29D2A416C44D04BCFA9D38C835E4D2D18C2E9BF0AC04635044CBF46711413B902B559256D2D53F84E65A616DF4AD90F16320A7D4BC4773B1C286564"
+                },
+                {
+                    "tc_id": 19,
+                    "comment": "Aggregation with three tweaks applied (one x-only, two plain)",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "tweak_indices": [0, 1, 2],
+                    "is_xonly": [true, false, false],
+                    "psigs": [
+                        "770F3D44887BDBBDF9677EA60A15EB76D7B8F902380F37F18410E20D0098D9C0",
+                        "716296B6D612CA76BBD15CAD9E7C4D4B4DF21A45EDD56A29F4DE6C43E412784F",
+                        "C119785E757BE23896CD7EC52F8255AD7A884E459DD4E201C379E4BA636E5CD3"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "77C86962FF9E39A6372B526890AF9E74D2A3AFAADFE98B1027448792426B2ECFFA1886EA901A10640C4ACAE261E133110D005F13AED5F84BFD52FA8910AD8EA1"
+                },
+                {
+                    "tc_id": 20,
+                    "comment": "All signers participate, no tweaks",
+                    "ids": [0, 1, 2, 3, 4],
+                    "pubshare_indices": [0, 1, 2, 3, 4],
+                    "aggnonce": "03536024F21D3C18E0F094D15E9DDA07740754905570A1B68CAFAC743A6C213745037C9EA6730CD21904C131FF4A6C62480A7BABAA75F0A4F63F1AFD8DEE9FDD699D",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "6336EBA6F79E63DE2C31882D8CFC00B6E307D4C3F169346EE70DF0F82A74E9CC",
+                        "EE624D5540B13082E7F4385188485CB757978F2A84A3E72B7D09DE1760558AAC",
+                        "3F69A9D808A052C2151C68FDC7DB78C7581E6774B6FBC7C344DCB2A44C74E650",
+                        "F4E0DDFF8DDE7745DD787B966F2B5F31A047ADB702E9EA8D2260D8E5BA2B3901",
+                        "7B9D33EF9A490DDFC3628A7EFA6AD78CE9989AAD57C7271DFDA34CB9CF86F7EE"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "0CC7BC744D06AE2B185A7E0799E963F092582CB412955456A1D0B85A064A3AFA0180F4C369176C48CA1D2F9246B60CF7EC917D1379E0145589818BACF04EC7F4"
+                }
+            ],
+            "error_tests": [
+                {
+                    "tc_id": 21,
+                    "comment": "Partial signature equals the group order, which is out of range",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "96630BAD23F362F641D8B88D89F006B2BB3EC7390D80743997ECFC9C96A13AD3",
+                        "2EA9B38288385D6AB64FAEDC74ADF407BA7FF74926E85A10A3B3A6B45C98BD6D",
+                        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141"
+                    ],
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": 2,
+                        "contrib": "psig"
+                    }
+                },
+                {
+                    "tc_id": 22,
+                    "comment": "Number of partial signatures does not match the number of signers",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "psigs": [
+                        "96630BAD23F362F641D8B88D89F006B2BB3EC7390D80743997ECFC9C96A13AD3",
+                        "2EA9B38288385D6AB64FAEDC74ADF407BA7FF74926E85A10A3B3A6B45C98BD6D"
                     ],
                     "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
                     "error": {

--- a/python/vectors/sign_verify_vectors.json
+++ b/python/vectors/sign_verify_vectors.json
@@ -73,7 +73,7 @@
                 },
                 {
                     "tc_id": 4,
-                    "comment": "All n=3 signers participate, signed by a non-first member in the set",
+                    "comment": "All signers participate, signed by a non-first member in the set",
                     "my_id": 1,
                     "ids": [0, 1, 2],
                     "pubshare_indices": [0, 1, 2],
@@ -127,7 +127,7 @@
             "sign_error_tests": [
                 {
                     "tc_id": 8,
-                    "comment": "my_id is not in the signer set",
+                    "comment": "Signer's identifier is absent from the signer set",
                     "my_id": 2,
                     "ids": [0, 1],
                     "pubshare_indices": [0, 1],
@@ -163,7 +163,7 @@
                     "pubshare_indices": [1, 2],
                     "secshare_index": 0,
                     "secnonce_index": 0,
-                    "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
+                    "aggnonce": "033334D94EBA8ED8D3CD7CDD4430F0EE85A207917A12DF12DFE08E1861B004A6D4033D71B2938B48516AB2EE546C5EC36D0EFFBF0B3E290E9084CE5606394395EE5A",
                     "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
                     "error": {
                         "type": "ValueError",
@@ -205,7 +205,7 @@
                     "comment": "Signer set's public shares do not match the threshold public key",
                     "my_id": 0,
                     "ids": [0, 1],
-                    "pubshare_indices": [0, 2],
+                    "pubshare_indices": [1, 0],
                     "secshare_index": 0,
                     "secnonce_index": 0,
                     "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
@@ -379,6 +379,1079 @@
                     "ids": [0, 1],
                     "pubshare_indices": [3, 1],
                     "pubnonce_indices": [0, 1],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "Invalid pubshare at index 0."
+                    }
+                }
+            ]
+        },
+        {
+            "tg_id": "1of3",
+            "t": 1,
+            "n": 3,
+            "thresh_pk": "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F",
+            "pubshares": [
+                "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F",
+                "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F",
+                "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F",
+                "020000000000000000000000000000000000000000000000000000000000000007"
+            ],
+            "pubnonces": [
+                "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                "0200000000000000000000000000000000000000000000000000000000000000090287BF891D2A6DEAEBADC909352AA9405D1428C15F4B75F04DAE642A95C2548480",
+                "02FBEA8F3C4CCA7DFD6BD61F7DF7B49BE720D0DE014144457C1EEB0882B40CA76B03289A43F164E3403CDA987383887BB807EB8CF3329949DC80C3DD5D757EF4B841"
+            ],
+            "secshares": [
+                "06D47E05E97481428654563E5AE69C20C49642773B7334220E63110259A30C32",
+                "06D47E05E97481428654563E5AE69C20C49642773B7334220E63110259A30C32",
+                "06D47E05E97481428654563E5AE69C20C49642773B7334220E63110259A30C32",
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            ],
+            "secnonces": [
+                "85988D37E7F2EE21FC47295E90D0FD85027CE0E71DA37B36CFB55BD471D3BA82ACE9F73C19DCD387AEF30F9E894564A47F8BE85FAAAE710DD0F442DF2A380190",
+                "85988D37E7F2EE21FC47295E90D0FD85027CE0E71DA37B36CFB55BD471D3BA82ACE9F73C19DCD387AEF30F9E894564A47F8BE85FAAAE710DD0F442DF2A380190",
+                "85988D37E7F2EE21FC47295E90D0FD85027CE0E71DA37B36CFB55BD471D3BA82ACE9F73C19DCD387AEF30F9E894564A47F8BE85FAAAE710DD0F442DF2A380190",
+                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                "85988D37E7F2EE21FC47295E90D0FD85027CE0E71DA37B36CFB55BD471D3BA820000000000000000000000000000000000000000000000000000000000000000"
+            ],
+            "valid_tests": [
+                {
+                    "tc_id": 26,
+                    "comment": "Minimum threshold subset of signers",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "pubnonce_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "0662F783275AEB48C647E93D941AD63AF0A53F05C31C19153D203D68DAFF2831"
+                },
+                {
+                    "tc_id": 27,
+                    "comment": "All signers participate, signed by a non-first member in the set",
+                    "my_id": 1,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 1,
+                    "secnonce_index": 1,
+                    "aggnonce": "0277E716756BAEFD922DCD339D083FEB1C0263B06999328492331FB876A225EEA3033910C4FC151C7AA914B4D2AC97B3F09C56A36A5F95F14043D90210CC1FCD4245",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "010D7844DBD7DCDE861BA2DEAEBF1EDB620446760857FC88A18C3735496F1306"
+                },
+                {
+                    "tc_id": 28,
+                    "comment": "Aggregate nonce is the point at infinity, so the final nonce point falls back to the generator G",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 4],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "E128865B1A8286740EA76D8D2188FEB3322D34F36A8E1F1593B655F50EF392FF"
+                },
+                {
+                    "tc_id": 29,
+                    "comment": "Empty message",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "pubnonce_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "",
+                    "expected": "996482A3C99DA47A225CBE6A85CC64D391ACE8C232E5DEED0000F0D7B248CBE4"
+                },
+                {
+                    "tc_id": 30,
+                    "comment": "Non-standard message length (38 bytes)",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "pubnonce_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "2626262626262626262626262626262626262626262626262626262626262626262626262626",
+                    "expected": "FEC0E03F4E2BBB84BD1D9B5D3B6F72915D282AF995679ECDCF5F00D74CFED683"
+                }
+            ],
+            "sign_error_tests": [
+                {
+                    "tc_id": 31,
+                    "comment": "Signer's identifier is absent from the signer set",
+                    "my_id": 1,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's id must be present in the participant identifier list."
+                    }
+                },
+                {
+                    "tc_id": 32,
+                    "comment": "Signer set contains a duplicate id",
+                    "my_id": 0,
+                    "ids": [0, 1, 1],
+                    "pubshare_indices": [0, 1, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The participant identifier list contains duplicate elements."
+                    }
+                },
+                {
+                    "tc_id": 33,
+                    "comment": "A public share is not a valid point",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 3],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "03FBEA8F3C4CCA7DFD6BD61F7DF7B49BE720D0DE014144457C1EEB0882B40CA76B02289A43F164E3403CDA987383887BB807EB8CF3329949DC80C3DD5D757EF4B841",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "Invalid pubshare at index 1."
+                    }
+                },
+                {
+                    "tc_id": 34,
+                    "comment": "A signer id is outside the valid range [0, n-1]",
+                    "my_id": 0,
+                    "ids": [3],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The participant identifier at index 0 is out of range."
+                    }
+                },
+                {
+                    "tc_id": 35,
+                    "comment": "Aggregate nonce is invalid: first half has an unknown tag 0x04",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "048465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61037496A3CC86926D452CAFCFD55D25972CA1675D549310DE296BFF42F72EEEA8C9",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggnonce"
+                    }
+                },
+                {
+                    "tc_id": 36,
+                    "comment": "Aggregate nonce is invalid: second half is not a point on the curve",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61020000000000000000000000000000000000000000000000000000000000000009",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggnonce"
+                    }
+                },
+                {
+                    "tc_id": 37,
+                    "comment": "Aggregate nonce is invalid: second half's x-coordinate exceeds the field size",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD6102FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggnonce"
+                    }
+                },
+                {
+                    "tc_id": 38,
+                    "comment": "Secret nonce's first half is out of range (all-zero nonce, which may indicate nonce reuse)",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 3,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "first secnonce value is out of range."
+                    }
+                },
+                {
+                    "tc_id": 39,
+                    "comment": "Secret nonce's second half is out of range (zero)",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 4,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "second secnonce value is out of range."
+                    }
+                },
+                {
+                    "tc_id": 40,
+                    "comment": "Fewer signers than the threshold t",
+                    "my_id": 0,
+                    "ids": [],
+                    "pubshare_indices": [],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The number of signers must be between t and n."
+                    }
+                },
+                {
+                    "tc_id": 41,
+                    "comment": "Secret share is out of range (zero)",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 3,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's secret share value is out of range."
+                    }
+                }
+            ],
+            "verify_fail_tests": [
+                {
+                    "tc_id": 42,
+                    "comment": "Negated partial signature fails the verification equation",
+                    "psig": "B6BA032DAEC58A6B9E92062AD48513B3BD44E727895919A847D9D043009CBE52",
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "pubnonce_indices": [0, 1],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF"
+                },
+                {
+                    "tc_id": 43,
+                    "comment": "A valid partial signature checked against the wrong signer fails the verification equation",
+                    "psig": "4945FCD2513A7594616DF9D52B7AEC4AFD69F5BF25EF869377F88E49CF9982EF",
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "pubnonce_indices": [0, 1],
+                    "signer_index": 1,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF"
+                },
+                {
+                    "tc_id": 44,
+                    "comment": "Partial signature equals the group order, which is out of range",
+                    "psig": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "pubnonce_indices": [0, 1],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF"
+                }
+            ],
+            "verify_error_tests": [
+                {
+                    "tc_id": 45,
+                    "comment": "Verification rejects an invalid public nonce, blaming the malicious signer",
+                    "psig": "0662F783275AEB48C647E93D941AD63AF0A53F05C31C19153D203D68DAFF2831",
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "pubnonce_indices": [3],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": 0,
+                        "contrib": "pubnonce"
+                    }
+                },
+                {
+                    "tc_id": 46,
+                    "comment": "A public share is not a valid point",
+                    "psig": "0662F783275AEB48C647E93D941AD63AF0A53F05C31C19153D203D68DAFF2831",
+                    "ids": [0],
+                    "pubshare_indices": [3],
+                    "pubnonce_indices": [0],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "Invalid pubshare at index 0."
+                    }
+                }
+            ]
+        },
+        {
+            "tg_id": "3of3",
+            "t": 3,
+            "n": 3,
+            "thresh_pk": "023E94D6A68620D3F60221A4186786274A711221A8BBB31A5388DFA6718E8EF7BB",
+            "pubshares": [
+                "03A3E932BA9DD0063D721590B6EF21DD4566A97B203343FDE9DA5815DB9BE049CA",
+                "0201E5FEAC0DB5059C32B045F37799101A96262B3C88CE85D610451FC21A0457FF",
+                "03EF72D10D1DFE4E786619536A458507CAF105FCCDB8173DAF2E358054AF2FA4A2",
+                "020000000000000000000000000000000000000000000000000000000000000007"
+            ],
+            "pubnonces": [
+                "02B6418EDDC3E2D48B064BE46F71CEDE3A34594DEAC6E7F6707C8A71CB523EA58602C0B402216E9952E649B8CCFEDBAC6AA10BAEEFF4C02EEAA1148E87C7B21BDFB7",
+                "02B63A2B319D64A7BFE6634404CB9D80AAA57BAFD8AA01FC52BF77232DC0EE4B600358E8B8F6FB17FB5D92FAFAC1093773645FE32330D6E2774B4BBBCEF7DDFA5102",
+                "0364F60E66B7BC35A332B4F9688BD5CA2EF508E25C691D6A1A194097D170BBCCE602494AB47255521F0134EC7C41079A8955DA7220172A60371DC32C696AE5D61410",
+                "0200000000000000000000000000000000000000000000000000000000000000090287BF891D2A6DEAEBADC909352AA9405D1428C15F4B75F04DAE642A95C2548480",
+                "0335CCFFD0F3A9110FF368B72360D76A9940910BD2DB6C2CCC26F2C4DA984A1E9B03502D16AC8AE6322A0AE9A8CBE887158DE8236A6F1C510B2D5D06F00A851B48D0"
+            ],
+            "secshares": [
+                "D4DE571C662C319E7C4F46420F5ACBEFD2D905C3B52771C553DE1F76197D940D",
+                "0EAAC017ABA2030272B7F8EAAD68E22BF07F08950D7B570B69B2CCEF278D52C1",
+                "1E4E4344B9B59410588CCF327B766E4D298882D904F0FBF288C86B73AC5962A3",
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            ],
+            "secnonces": [
+                "7B2247A3980C88714A0821F230F689F436FBF80B0B6DED33540B92CB65BA6ED149A8ADAF97EF6DBAA6015CD5BA84E4CAADB7A453508DD17FD8EE3618E119C0F9",
+                "B1456FA8F924860A665AFC2AE2746E6E2C99EBBE4BC1D0F5BD00BC52CB7DFD79A823D92911393852D4ECCC59387DB88C526FD1AD7574A3336893B618750DBDDD",
+                "C309D4BC0457A9D6031CDAC33BAFA47BAB2334445BF22D09E1936F919756D275BC09410F5D39E5D701C81BBA99E4E95F9E07FFC32C322F25604582CB242DD46A",
+                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                "7B2247A3980C88714A0821F230F689F436FBF80B0B6DED33540B92CB65BA6ED10000000000000000000000000000000000000000000000000000000000000000"
+            ],
+            "valid_tests": [
+                {
+                    "tc_id": 47,
+                    "comment": "Minimum threshold subset of signers",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "08A866ABF049F70B7D842680EDB78C1C742D0368090B9F579CBE9D7019F53A8D"
+                },
+                {
+                    "tc_id": 48,
+                    "comment": "Reordering the signer set leaves the partial signature unchanged, because the identifiers are sorted before they are bound into the binding value",
+                    "my_id": 0,
+                    "ids": [2, 1, 0],
+                    "pubshare_indices": [2, 1, 0],
+                    "pubnonce_indices": [2, 1, 0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "08A866ABF049F70B7D842680EDB78C1C742D0368090B9F579CBE9D7019F53A8D"
+                },
+                {
+                    "tc_id": 49,
+                    "comment": "All signers participate, signed by a non-first member in the set",
+                    "my_id": 1,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 1,
+                    "secnonce_index": 1,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "6D180D3D1776FC298E1F00F806D8444EA597749245ED88E05B0FF08C98AA6316"
+                },
+                {
+                    "tc_id": 50,
+                    "comment": "Aggregate nonce is the point at infinity, so the final nonce point falls back to the generator G",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 4],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "2EFF6BA537599ACDD23E18BF07D639C524F6FE2C13E20C5D1ABC6A06A49E8272"
+                },
+                {
+                    "tc_id": 51,
+                    "comment": "Empty message",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "",
+                    "expected": "FC83936BE88FFE128B3FD58D93A57D58C2705D55926D6FF3ACDA0B112BC790B2"
+                },
+                {
+                    "tc_id": 52,
+                    "comment": "Non-standard message length (38 bytes)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "2626262626262626262626262626262626262626262626262626262626262626262626262626",
+                    "expected": "0D59B34C9B1BBE46767899798CA3DED2C6531D9FE35ADDCED398B960E9B3B927"
+                }
+            ],
+            "sign_error_tests": [
+                {
+                    "tc_id": 53,
+                    "comment": "Signer set contains a duplicate id",
+                    "my_id": 0,
+                    "ids": [0, 1, 1],
+                    "pubshare_indices": [0, 1, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The participant identifier list contains duplicate elements."
+                    }
+                },
+                {
+                    "tc_id": 54,
+                    "comment": "A public share is not a valid point",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 3, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "Invalid pubshare at index 1."
+                    }
+                },
+                {
+                    "tc_id": 55,
+                    "comment": "A signer id is outside the valid range [0, n-1]",
+                    "my_id": 1,
+                    "ids": [3, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 1,
+                    "secnonce_index": 1,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The participant identifier at index 0 is out of range."
+                    }
+                },
+                {
+                    "tc_id": 56,
+                    "comment": "Signer set's public shares do not match the threshold public key",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 2, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The provided key material is incorrect."
+                    }
+                },
+                {
+                    "tc_id": 57,
+                    "comment": "Aggregate nonce is invalid: first half has an unknown tag 0x04",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "048465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61037496A3CC86926D452CAFCFD55D25972CA1675D549310DE296BFF42F72EEEA8C9",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggnonce"
+                    }
+                },
+                {
+                    "tc_id": 58,
+                    "comment": "Aggregate nonce is invalid: second half is not a point on the curve",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61020000000000000000000000000000000000000000000000000000000000000009",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggnonce"
+                    }
+                },
+                {
+                    "tc_id": 59,
+                    "comment": "Aggregate nonce is invalid: second half's x-coordinate exceeds the field size",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD6102FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggnonce"
+                    }
+                },
+                {
+                    "tc_id": 60,
+                    "comment": "Secret nonce's first half is out of range (all-zero nonce, which may indicate nonce reuse)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 3,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "first secnonce value is out of range."
+                    }
+                },
+                {
+                    "tc_id": 61,
+                    "comment": "Secret nonce's second half is out of range (zero)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 4,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "second secnonce value is out of range."
+                    }
+                },
+                {
+                    "tc_id": 62,
+                    "comment": "Fewer signers than the threshold t",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The number of signers must be between t and n."
+                    }
+                },
+                {
+                    "tc_id": 63,
+                    "comment": "Secret share is out of range (zero)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 3,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's secret share value is out of range."
+                    }
+                }
+            ],
+            "verify_fail_tests": [
+                {
+                    "tc_id": 64,
+                    "comment": "Negated partial signature fails the verification equation",
+                    "psig": "F75799540FB608F4827BD97F124873E24681D97EA63D00E42313C11CB64106B4",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF"
+                },
+                {
+                    "tc_id": 65,
+                    "comment": "A valid partial signature checked against the wrong signer fails the verification equation",
+                    "psig": "08A866ABF049F70B7D842680EDB78C1C742D0368090B9F579CBE9D7019F53A8D",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "signer_index": 1,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF"
+                },
+                {
+                    "tc_id": 66,
+                    "comment": "Partial signature equals the group order, which is out of range",
+                    "psig": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF"
+                }
+            ],
+            "verify_error_tests": [
+                {
+                    "tc_id": 67,
+                    "comment": "Verification rejects an invalid public nonce, blaming the malicious signer",
+                    "psig": "08A866ABF049F70B7D842680EDB78C1C742D0368090B9F579CBE9D7019F53A8D",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [3, 1, 2],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": 0,
+                        "contrib": "pubnonce"
+                    }
+                },
+                {
+                    "tc_id": 68,
+                    "comment": "A public share is not a valid point",
+                    "psig": "08A866ABF049F70B7D842680EDB78C1C742D0368090B9F579CBE9D7019F53A8D",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [3, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "Invalid pubshare at index 0."
+                    }
+                }
+            ]
+        },
+        {
+            "tg_id": "3of5",
+            "t": 3,
+            "n": 5,
+            "thresh_pk": "03E1AEA00A7B8D0E0393664FEBBD31569A02CAF223D9AD83E90331DC18B1987358",
+            "pubshares": [
+                "02F333EDD2B6F532C2EF6C42E803B633A42289D0567A75C50EB1C8CF85EC480E8F",
+                "025322F63602ECCF146541B7C9EE4D1FCB84EC139471420472182AE968676A387F",
+                "0230639CEC0A83982E176D6905CE0620FDC57E151565A39D0E0821B8E753AE85B0",
+                "026E1A50E672FEDD3F3C378D6121E5702B050669DBC241D2C2299880152CD207BD",
+                "02DC06C4CA919DE70B4B8281901CCF9471AB91FBFBEE1A8C570D83911CAAF9E2FA",
+                "020000000000000000000000000000000000000000000000000000000000000007"
+            ],
+            "pubnonces": [
+                "02EBD21E4F4EA2772BD4E427D98C9DC268894D18EC45E14063785B892D42921FF402FB73028B710ACBE49FC2D995757E077760CA7C1B2452791A3BDA086B91A1CEF3",
+                "02BCBEF1171F78857016B205C0C9DE61750CC21448C167AAFAFD9190962AEAFF79032798E533A65F94D1DFF901A2CB4F107D49FE6B0527E95D7AE24E4DBBB681F552",
+                "02A455D731ECDCAA59228CE82CA1B5CF45974F6E6D21EB57501BE22310F089BF69037E2647E73C022A913C87D8813D48E76D72313DF4697644C23DDE820DBEF76D4A",
+                "026730E278BDB65A8E771864103890A1F10BA5AB9B429E0843CCB45FD2D9052C6A03525D89B7C9615F846D36223D777C5D6BF134FD1981FCB2F6B94F7FA70CE668AB",
+                "034D048ED3554BE5D0F03308936060FAAA8A0889FD135E8176DC0843C4FB68A89903497442C3AC05C98A8FDDB40646A6203A6EA53E20846F8D0A863447011BE8EA71",
+                "0200000000000000000000000000000000000000000000000000000000000000090287BF891D2A6DEAEBADC909352AA9405D1428C15F4B75F04DAE642A95C2548480",
+                "0342B812EE2B499BAC6AAE1CC4F3B2E0739D0C3DCB558513DC737AAA4B7F5BF7DE023AFC98C8EBD47B2277E650056543F287E4585BC8419F472D6A3FC3E5D2B42D4A"
+            ],
+            "secshares": [
+                "77C9316A64770B17D500840E020A9478F793D37DB0E6A276CB4E6270187D6C90",
+                "74180420A784189B55F8C4667075E89C2064FF481B6ED2A23A7517AF71F6B7A8",
+                "BE6B9FB07586EBABD234EEE0A05E813DFFC14D73782085C8DFE77C1FADDA7172",
+                "56C40419CE7F844949B5037C91C45E5FDAF9E11917B31BAEFBD33133FBF258AD",
+                "3D21315CB26DE273BC79023A44A780006CBD971FA96F34904E0A95792C74AE9A",
+                "0000000000000000000000000000000000000000000000000000000000000000"
+            ],
+            "secnonces": [
+                "8A1160479C4188DA237C53639EDEFC60C24E87F91AC8972D966000680A7D07328A5318B81726CB9B16B9321264611C7DF0C737BB64941F79D403D2D503FAB3AB",
+                "38214C927297FD9F61722C93A6568A7CFE37D8BFA7C73822337FEA77AD97A325CB33A2D2CB486A6F2EE597D7ED9D5552DD096452E3AC9DFA9787019BAB7652EB",
+                "E3490427C987333662C649E5801683B8BFCB7E5F0725908DBC968AA86AF1FA2C10E4690766A547CA58136EF3DC1045A8C3ECEA532A057F1A1AF1E42761E0ECD7",
+                "EE855A53463521DECAFA1132D121644CF0BBA4A860456F26540261023D9A49910E40FA146B6B9D4B8914D57D0B14A03BF5C753067CC144C69C14D924F037EF9E",
+                "CE5F5A722536E56561C5C1258A8E6A38480A7D00F79645460CCA3DE7F10E480308EF46C644D01F0FCB05950F384C655198101BDD83C604A8484FCCB49914CC39",
+                "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                "8A1160479C4188DA237C53639EDEFC60C24E87F91AC8972D966000680A7D07320000000000000000000000000000000000000000000000000000000000000000"
+            ],
+            "valid_tests": [
+                {
+                    "tc_id": 69,
+                    "comment": "Minimum threshold subset of signers",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "96630BAD23F362F641D8B88D89F006B2BB3EC7390D80743997ECFC9C96A13AD3"
+                },
+                {
+                    "tc_id": 70,
+                    "comment": "Reordering the signer set leaves the partial signature unchanged, because the identifiers are sorted before they are bound into the binding value",
+                    "my_id": 0,
+                    "ids": [2, 1, 0],
+                    "pubshare_indices": [2, 1, 0],
+                    "pubnonce_indices": [2, 1, 0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "96630BAD23F362F641D8B88D89F006B2BB3EC7390D80743997ECFC9C96A13AD3"
+                },
+                {
+                    "tc_id": 71,
+                    "comment": "A different threshold subset gives a different partial signature, since the Lagrange coefficients depend on the signer set",
+                    "my_id": 0,
+                    "ids": [0, 3, 4],
+                    "pubshare_indices": [0, 3, 4],
+                    "pubnonce_indices": [0, 3, 4],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "03CE3C1C182829F31DE2E6FD057A06CFA52376FEE42C3FBD487C19CFF3B5C70DC5020D9DD41C4A2B9B43DB7C4E93B7C504946446636F25C5D893E90C626286D90765",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "BB2E12DF70774F9F5583A620F0F73217FA9C21E27A4C065D3A9A69D90195ADBF"
+                },
+                {
+                    "tc_id": 72,
+                    "comment": "All signers participate, signed by a non-first member in the set",
+                    "my_id": 1,
+                    "ids": [0, 1, 2, 3, 4],
+                    "pubshare_indices": [0, 1, 2, 3, 4],
+                    "pubnonce_indices": [0, 1, 2, 3, 4],
+                    "secshare_index": 1,
+                    "secnonce_index": 1,
+                    "aggnonce": "03536024F21D3C18E0F094D15E9DDA07740754905570A1B68CAFAC743A6C213745037C9EA6730CD21904C131FF4A6C62480A7BABAA75F0A4F63F1AFD8DEE9FDD699D",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "EE624D5540B13082E7F4385188485CB757978F2A84A3E72B7D09DE1760558AAC"
+                },
+                {
+                    "tc_id": 73,
+                    "comment": "Aggregate nonce is the point at infinity, so the final nonce point falls back to the generator G",
+                    "my_id": 0,
+                    "ids": [0, 1, 2, 3, 4],
+                    "pubshare_indices": [0, 1, 2, 3, 4],
+                    "pubnonce_indices": [0, 1, 2, 3, 6],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "expected": "559961C1086B45BA3E083E32EF837A2636ADA8BDE5FF0F1823ADDE9A414A5AB1"
+                },
+                {
+                    "tc_id": 74,
+                    "comment": "Empty message",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "",
+                    "expected": "8943BF49C69B9243584C218666141D0C4D13ED1FE42A183340619E33FE514844"
+                },
+                {
+                    "tc_id": 75,
+                    "comment": "Non-standard message length (38 bytes)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "2626262626262626262626262626262626262626262626262626262626262626262626262626",
+                    "expected": "6A950ECF293909B8AD4C59E09399626C6577664FE43B1D34F7423ABE41F1DF9A"
+                }
+            ],
+            "sign_error_tests": [
+                {
+                    "tc_id": 76,
+                    "comment": "Signer's identifier is absent from the signer set",
+                    "my_id": 3,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's id must be present in the participant identifier list."
+                    }
+                },
+                {
+                    "tc_id": 77,
+                    "comment": "Signer set contains a duplicate id",
+                    "my_id": 0,
+                    "ids": [0, 1, 1],
+                    "pubshare_indices": [0, 1, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The participant identifier list contains duplicate elements."
+                    }
+                },
+                {
+                    "tc_id": 78,
+                    "comment": "Signer's public share is not in the public share list",
+                    "my_id": 1,
+                    "ids": [1, 2, 3],
+                    "pubshare_indices": [1, 2, 3],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "027FEAEF20E0DF0EC419CF5D4FCE8CB18D14B051A1A3A0374E9AB42F2E637BCDC802F76F1B7F5C275C6278AA61138560262606C84E66478C0E20B3980D9B029F5F3C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's pubshare must be included in the list of pubshares."
+                    }
+                },
+                {
+                    "tc_id": 79,
+                    "comment": "A public share is not a valid point",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 5, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "Invalid pubshare at index 1."
+                    }
+                },
+                {
+                    "tc_id": 80,
+                    "comment": "A signer id is outside the valid range [0, n-1]",
+                    "my_id": 1,
+                    "ids": [5, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 1,
+                    "secnonce_index": 1,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The participant identifier at index 0 is out of range."
+                    }
+                },
+                {
+                    "tc_id": 81,
+                    "comment": "Signer set's public shares do not match the threshold public key",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 2, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The provided key material is incorrect."
+                    }
+                },
+                {
+                    "tc_id": 82,
+                    "comment": "Aggregate nonce is invalid: first half has an unknown tag 0x04",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "048465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61037496A3CC86926D452CAFCFD55D25972CA1675D549310DE296BFF42F72EEEA8C9",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggnonce"
+                    }
+                },
+                {
+                    "tc_id": 83,
+                    "comment": "Aggregate nonce is invalid: second half is not a point on the curve",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61020000000000000000000000000000000000000000000000000000000000000009",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggnonce"
+                    }
+                },
+                {
+                    "tc_id": 84,
+                    "comment": "Aggregate nonce is invalid: second half's x-coordinate exceeds the field size",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD6102FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC30",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": null,
+                        "contrib": "aggnonce"
+                    }
+                },
+                {
+                    "tc_id": 85,
+                    "comment": "Secret nonce's first half is out of range (all-zero nonce, which may indicate nonce reuse)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 5,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "first secnonce value is out of range."
+                    }
+                },
+                {
+                    "tc_id": 86,
+                    "comment": "Secret nonce's second half is out of range (zero)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 6,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "second secnonce value is out of range."
+                    }
+                },
+                {
+                    "tc_id": 87,
+                    "comment": "Fewer signers than the threshold t",
+                    "my_id": 0,
+                    "ids": [0, 1],
+                    "pubshare_indices": [0, 1],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The number of signers must be between t and n."
+                    }
+                },
+                {
+                    "tc_id": 88,
+                    "comment": "Secret share is out of range (zero)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 5,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The signer's secret share value is out of range."
+                    }
+                }
+            ],
+            "verify_fail_tests": [
+                {
+                    "tc_id": 89,
+                    "comment": "Negated partial signature fails the verification equation",
+                    "psig": "699CF452DC0C9D09BE274772760FF94BFF7015ADA1C82C0227E561F03995066E",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF"
+                },
+                {
+                    "tc_id": 90,
+                    "comment": "A valid partial signature checked against the wrong signer fails the verification equation",
+                    "psig": "96630BAD23F362F641D8B88D89F006B2BB3EC7390D80743997ECFC9C96A13AD3",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "signer_index": 1,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF"
+                },
+                {
+                    "tc_id": 91,
+                    "comment": "Partial signature equals the group order, which is out of range",
+                    "psig": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF"
+                }
+            ],
+            "verify_error_tests": [
+                {
+                    "tc_id": 92,
+                    "comment": "Verification rejects an invalid public nonce, blaming the malicious signer",
+                    "psig": "96630BAD23F362F641D8B88D89F006B2BB3EC7390D80743997ECFC9C96A13AD3",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [5, 1, 2],
+                    "signer_index": 0,
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "error": {
+                        "type": "InvalidContributionError",
+                        "signer_index": 0,
+                        "contrib": "pubnonce"
+                    }
+                },
+                {
+                    "tc_id": 93,
+                    "comment": "A public share is not a valid point",
+                    "psig": "96630BAD23F362F641D8B88D89F006B2BB3EC7390D80743997ECFC9C96A13AD3",
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [5, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
                     "signer_index": 0,
                     "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
                     "error": {

--- a/python/vectors/sign_verify_vectors.json
+++ b/python/vectors/sign_verify_vectors.json
@@ -34,7 +34,7 @@
             "valid_tests": [
                 {
                     "tc_id": 1,
-                    "comment": "Minimum threshold subset of signers (t=2 of n=3)",
+                    "comment": "Minimum threshold subset of signers",
                     "my_id": 0,
                     "ids": [0, 1],
                     "pubshare_indices": [0, 1],
@@ -359,7 +359,7 @@
             "verify_error_tests": [
                 {
                     "tc_id": 24,
-                    "comment": "Verification rejects an invalid public nonce, attributing the contribution fault to the offending signer",
+                    "comment": "Verification rejects an invalid public nonce, blaming the malicious signer",
                     "psig": "2B69442F9BCE21BB722831A2150FB9A6DF6D0288D39E2E4F5687E92A3C4A7862",
                     "ids": [0, 1],
                     "pubshare_indices": [0, 1],

--- a/python/vectors/sign_verify_vectors.json
+++ b/python/vectors/sign_verify_vectors.json
@@ -73,7 +73,7 @@
                 },
                 {
                     "tc_id": 4,
-                    "comment": "All signers participate, signed by a non-first member in the set",
+                    "comment": "All signers participate, signed by a non-first member of the signer set",
                     "my_id": 1,
                     "ids": [0, 1, 2],
                     "pubshare_indices": [0, 1, 2],
@@ -435,7 +435,7 @@
                 },
                 {
                     "tc_id": 27,
-                    "comment": "All signers participate, signed by a non-first member in the set",
+                    "comment": "All signers participate, signed by a non-first member of the signer set",
                     "my_id": 1,
                     "ids": [0, 1, 2],
                     "pubshare_indices": [0, 1, 2],
@@ -780,7 +780,7 @@
                 },
                 {
                     "tc_id": 49,
-                    "comment": "All signers participate, signed by a non-first member in the set",
+                    "comment": "All signers participate, signed by a non-first member of the signer set",
                     "my_id": 1,
                     "ids": [0, 1, 2],
                     "pubshare_indices": [0, 1, 2],
@@ -1146,7 +1146,7 @@
                 },
                 {
                     "tc_id": 72,
-                    "comment": "All signers participate, signed by a non-first member in the set",
+                    "comment": "All signers participate, signed by a non-first member of the signer set",
                     "my_id": 1,
                     "ids": [0, 1, 2, 3, 4],
                     "pubshare_indices": [0, 1, 2, 3, 4],

--- a/python/vectors/test_vectors_summary.md
+++ b/python/vectors/test_vectors_summary.md
@@ -18,9 +18,9 @@ the files.
 ## How test cases are laid out
 
 Most files don't repeat shared inputs inside every test case. Instead each file
-groups its cases under a `test_groups` array, and every group carries the key
-setup and the inputs it shares (`pubshares`, `pubnonces`, `secshares`,
-`secnonces`, `tweaks`). A case points into those shared inputs by index: a
+groups its cases under a `test_groups` array, one group per `(t, n)`
+configuration, and every group carries the key setup and the inputs it shares
+(`pubshares`, `pubnonces`, `secshares`, `secnonces`, `tweaks`). A case points into those shared inputs by index: a
 field named `<thing>_index` picks one entry, and `<thing>_indices` picks an
 ordered set. So to run a case, read its group's shared inputs, look up the
 case's indices in them, and call the function with the values you get back.
@@ -38,8 +38,8 @@ indices up, to trigger the failure it's testing.
 
 A few things stay out of that scheme:
 
-- `n`, `t`, and `thresh_pk` are group-level scalars you read directly (the
-  shared key setup), not part of the index scheme.
+- `tg_id`, `n`, `t`, and `thresh_pk` are group-level scalars you read directly
+  (the `(t, n)` label and the shared key setup), not part of the index scheme.
 - Per-session values stay inline in the case, with no shared input: the
   message (`msg`), the aggregate nonce (`aggnonce`, or `aggothernonce` in
   `det_sign`), and the signer's own id (`my_id`).
@@ -55,22 +55,27 @@ single-signer and uses no shared key, so every case inlines its own inputs.
 `nonce_agg` has no key material at all, so it keeps just a top-level
 `pubnonces` shared input that its cases index into.
 
-## The fixed key setup
+## The key setups
 
-Every file except `nonce_gen` and `nonce_agg` reuses one FROST setup from
-`frost_keygen_fixed()`: `n = 3`, `t = 2`, a shared `thresh_pk`, and
-identifiers `[0, 1, 2]`. Reusing the same `thresh_pk` everywhere lets you read
-the files as one consistent group. A fourth, bogus public share and a fourth
-identifier `3` also show up, but only error cases use them to trigger "invalid
-public share" and out-of-range-id failures, so don't treat them as valid
-signers.
+Every file except `nonce_gen` and `nonce_agg` carries four test groups, one
+per `(t, n)` configuration: `2-of-3`, `1-of-3`, `3-of-3`, and `3-of-5`. A
+group's `tg_id` names its configuration (for example `"3of5"`), and each group
+is generated independently, so it has its own `t`, `n`, `thresh_pk`, and `n`
+real signers with identifiers `0 .. n - 1`. The examples elsewhere in this
+document use the `2-of-3` group.
 
-Valid cases exercise different threshold-sized subsets of the three signers,
-so the `ids` list varies from case to case (for example `[0, 1]`, `[1, 0]`,
-`[0, 2]`, or the full `[0, 1, 2]`).
+In every group, one bogus public share and an out-of-range identifier (the
+value `n`) are appended after the real signers, but only error cases use them
+to trigger "invalid public share" and out-of-range-id failures, so don't treat
+them as valid signers.
 
-The `secshares` and `secnonces` shared inputs still carry the real secret
-material for all three signers at indices 0, 1, and 2, signer-aligned like the
+Valid cases exercise different threshold-sized subsets of the group's `n`
+signers, so the `ids` list varies from case to case: a single signer in the
+`1-of-3` group, three of five in `3-of-5`, and subsets like `[0, 1]`, `[1, 0]`,
+`[0, 2]`, or the full `[0, 1, 2]` in the `n = 3` groups.
+
+The `secshares` and `secnonces` shared inputs carry the real secret material
+for the group's `n` signers at indices `0 .. n - 1`, signer-aligned like the
 public ones. After those, a few deliberately bad entries are appended that
 only the error cases select: a zero secret share, an all-zero secret nonce,
 and a secret nonce whose second half is zero. Each case's `secshare_index` and

--- a/python/vectors/tweak_vectors.json
+++ b/python/vectors/tweak_vectors.json
@@ -8,8 +8,7 @@
             "pubshares": [
                 "039EE3335AF48DFE23702AB353F4AF20D401F67A130DF783CC8457323A860A2FB4",
                 "0284DC4AB2CB78A621EB87FA1F14BCE2B725AFEAAC981ADCBAFF5CC2D417D2A63A",
-                "036441EC2D4C1266201CD89B69549A2F5B2188612A0D434153E625FB38173DD509",
-                "020000000000000000000000000000000000000000000000000000000000000007"
+                "036441EC2D4C1266201CD89B69549A2F5B2188612A0D434153E625FB38173DD509"
             ],
             "pubnonces": [
                 "03FC0D3E212D25027356A2C9BB7EDC3B900DEA5E32AB10C03868E01C8490F9D36202C61389B6469B4345E00640CDC7ECA301547B97D30FC11AF410E23AD7B4BF69EE",
@@ -128,7 +127,7 @@
                 },
                 {
                     "tc_id": 7,
-                    "comment": "Same tweaks as the previous case but with all 3 signers and signed by a non-first member of the signer set",
+                    "comment": "Same tweaks as the previous case but with all signers participating, signed by a non-first member of the signer set",
                     "my_id": 1,
                     "ids": [0, 1, 2],
                     "pubshare_indices": [0, 1, 2],
@@ -203,6 +202,650 @@
                     "secshare_index": 0,
                     "secnonce_index": 0,
                     "aggnonce": "030F261BFE5DF0AE3EC06BB7A1D6394A3AF206968281F03B70D25FB84D49036CE203BE48277630579C72160430C819AABB1DFA20FF70749666080BB886B728476261",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [6],
+                    "is_xonly": [false],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The tweak must be a 32-byte array."
+                    }
+                }
+            ]
+        },
+        {
+            "tg_id": "1of3",
+            "t": 1,
+            "n": 3,
+            "thresh_pk": "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F",
+            "pubshares": [
+                "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F",
+                "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F",
+                "03D1939BE87D18EA5AB302E27077D16B2C2FD93516F91514BA049933D348DA441F"
+            ],
+            "pubnonces": [
+                "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57"
+            ],
+            "secshares": [
+                "06D47E05E97481428654563E5AE69C20C49642773B7334220E63110259A30C32",
+                "06D47E05E97481428654563E5AE69C20C49642773B7334220E63110259A30C32",
+                "06D47E05E97481428654563E5AE69C20C49642773B7334220E63110259A30C32"
+            ],
+            "secnonces": [
+                "85988D37E7F2EE21FC47295E90D0FD85027CE0E71DA37B36CFB55BD471D3BA82ACE9F73C19DCD387AEF30F9E894564A47F8BE85FAAAE710DD0F442DF2A380190",
+                "85988D37E7F2EE21FC47295E90D0FD85027CE0E71DA37B36CFB55BD471D3BA82ACE9F73C19DCD387AEF30F9E894564A47F8BE85FAAAE710DD0F442DF2A380190",
+                "85988D37E7F2EE21FC47295E90D0FD85027CE0E71DA37B36CFB55BD471D3BA82ACE9F73C19DCD387AEF30F9E894564A47F8BE85FAAAE710DD0F442DF2A380190"
+            ],
+            "tweaks": [
+                "E8F791FF9225A2AF0102AFFF4A9A723D9612A682A25EBE79802B263CDFCD83BB",
+                "AE2EA797CC0FE72AC5B97B97F3C6957D7E4199A167A58EB08BCAFFDA70AC0455",
+                "F52ECBC565B3D8BEA2DFD5B75A4F457E54369809322E4120831626F290FA87E0",
+                "1969AD73CC177FA0B4FCED6DF1F7BF9907E665FDE9BA196A74FED0A3CF5AEF9D",
+                "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
+                "F92B81FA168B7EBD79ABA9C1A51963DDF6189A6F73D56C19B16F4D8A7693350F",
+                "E8F791FF9225A2AF0102AFFF4A9A723D9612A682A25EBE79802B263CDFCD83BBFF"
+            ],
+            "valid_tests": [
+                {
+                    "tc_id": 12,
+                    "comment": "No tweaks applied",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "pubnonce_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "expected": "0662F783275AEB48C647E93D941AD63AF0A53F05C31C19153D203D68DAFF2831"
+                },
+                {
+                    "tc_id": 13,
+                    "comment": "Single x-only tweak (used for BIP341 Taproot)",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "pubnonce_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [0],
+                    "is_xonly": [true],
+                    "expected": "6A0F1F619F01E41CD05911AAF4C53D7F650454D238D44F9E2F7D3FEA2C65A112"
+                },
+                {
+                    "tc_id": 14,
+                    "comment": "Single plain tweak (used for BIP32 derivation)",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "pubnonce_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [0],
+                    "is_xonly": [false],
+                    "expected": "BCCADF64B166EFC477A89F7DC805CA4429FC5509F882CA073384772F2CEA84D4"
+                },
+                {
+                    "tc_id": 15,
+                    "comment": "A plain tweak followed by an x-only tweak",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "pubnonce_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [0, 1],
+                    "is_xonly": [false, true],
+                    "expected": "3139EF83EF488AC03D078077EFDC42DAD9B93799C877FF527B6EFD87072D99E2"
+                },
+                {
+                    "tc_id": 16,
+                    "comment": "Four tweaks alternating x-only and plain",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "pubnonce_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [0, 1, 2, 3],
+                    "is_xonly": [true, false, true, false],
+                    "expected": "C45C3034CBB4B0F37B880E20CF54263618187333885D92EC5C53732BFB368D07"
+                },
+                {
+                    "tc_id": 17,
+                    "comment": "Four tweaks: two plain followed by two x-only",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "pubnonce_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [0, 1, 2, 3],
+                    "is_xonly": [false, false, true, true],
+                    "expected": "8D736A8EC51940189121B993ECC27FC6D411761A4C6E935FB37EDA26FFB70969"
+                },
+                {
+                    "tc_id": 18,
+                    "comment": "Same tweaks as the previous case but with all signers participating, signed by a non-first member of the signer set",
+                    "my_id": 1,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 1,
+                    "secnonce_index": 1,
+                    "aggnonce": "0277E716756BAEFD922DCD339D083FEB1C0263B06999328492331FB876A225EEA3033910C4FC151C7AA914B4D2AC97B3F09C56A36A5F95F14043D90210CC1FCD4245",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [0, 1, 2, 3],
+                    "is_xonly": [false, false, true, true],
+                    "expected": "7C23569D6ABC6B7DD9D09AA98CAF85FE58D1C0AB9F2B7F0DADB64457868B7E54"
+                }
+            ],
+            "error_tests": [
+                {
+                    "tc_id": 19,
+                    "comment": "Tweak exceeds the group order",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [4],
+                    "is_xonly": [false],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The tweak value is out of range."
+                    }
+                },
+                {
+                    "tc_id": 20,
+                    "comment": "Plain tweak drives the tweaked threshold public key to the point at infinity",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [5],
+                    "is_xonly": [false],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The result of tweaking cannot be infinity."
+                    }
+                },
+                {
+                    "tc_id": 21,
+                    "comment": "Number of tweaks does not match the number of tweak modes",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [0],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The tweaks and is_xonly arrays must have the same length."
+                    }
+                },
+                {
+                    "tc_id": 22,
+                    "comment": "Tweak is not a 32-byte array",
+                    "my_id": 0,
+                    "ids": [0],
+                    "pubshare_indices": [0],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "026805DC7B318F796C360BB82F85FA0C106AB8775FECF892A0A7F85FB66720CBAB039509CF07C0A787AB8628C84E1F6F5E9CA424496D6ED4AC36722E5602E0C32C57",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [6],
+                    "is_xonly": [false],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The tweak must be a 32-byte array."
+                    }
+                }
+            ]
+        },
+        {
+            "tg_id": "3of3",
+            "t": 3,
+            "n": 3,
+            "thresh_pk": "023E94D6A68620D3F60221A4186786274A711221A8BBB31A5388DFA6718E8EF7BB",
+            "pubshares": [
+                "03A3E932BA9DD0063D721590B6EF21DD4566A97B203343FDE9DA5815DB9BE049CA",
+                "0201E5FEAC0DB5059C32B045F37799101A96262B3C88CE85D610451FC21A0457FF",
+                "03EF72D10D1DFE4E786619536A458507CAF105FCCDB8173DAF2E358054AF2FA4A2"
+            ],
+            "pubnonces": [
+                "02B6418EDDC3E2D48B064BE46F71CEDE3A34594DEAC6E7F6707C8A71CB523EA58602C0B402216E9952E649B8CCFEDBAC6AA10BAEEFF4C02EEAA1148E87C7B21BDFB7",
+                "02B63A2B319D64A7BFE6634404CB9D80AAA57BAFD8AA01FC52BF77232DC0EE4B600358E8B8F6FB17FB5D92FAFAC1093773645FE32330D6E2774B4BBBCEF7DDFA5102",
+                "0364F60E66B7BC35A332B4F9688BD5CA2EF508E25C691D6A1A194097D170BBCCE602494AB47255521F0134EC7C41079A8955DA7220172A60371DC32C696AE5D61410"
+            ],
+            "secshares": [
+                "D4DE571C662C319E7C4F46420F5ACBEFD2D905C3B52771C553DE1F76197D940D",
+                "0EAAC017ABA2030272B7F8EAAD68E22BF07F08950D7B570B69B2CCEF278D52C1",
+                "1E4E4344B9B59410588CCF327B766E4D298882D904F0FBF288C86B73AC5962A3"
+            ],
+            "secnonces": [
+                "7B2247A3980C88714A0821F230F689F436FBF80B0B6DED33540B92CB65BA6ED149A8ADAF97EF6DBAA6015CD5BA84E4CAADB7A453508DD17FD8EE3618E119C0F9",
+                "B1456FA8F924860A665AFC2AE2746E6E2C99EBBE4BC1D0F5BD00BC52CB7DFD79A823D92911393852D4ECCC59387DB88C526FD1AD7574A3336893B618750DBDDD",
+                "C309D4BC0457A9D6031CDAC33BAFA47BAB2334445BF22D09E1936F919756D275BC09410F5D39E5D701C81BBA99E4E95F9E07FFC32C322F25604582CB242DD46A"
+            ],
+            "tweaks": [
+                "E8F791FF9225A2AF0102AFFF4A9A723D9612A682A25EBE79802B263CDFCD83BB",
+                "AE2EA797CC0FE72AC5B97B97F3C6957D7E4199A167A58EB08BCAFFDA70AC0455",
+                "F52ECBC565B3D8BEA2DFD5B75A4F457E54369809322E4120831626F290FA87E0",
+                "1969AD73CC177FA0B4FCED6DF1F7BF9907E665FDE9BA196A74FED0A3CF5AEF9D",
+                "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
+                "8F16F7AD16ABE01B8AAD48C75EB3D4635F761C4F11E49492F82CB89DEE789D3C",
+                "E8F791FF9225A2AF0102AFFF4A9A723D9612A682A25EBE79802B263CDFCD83BBFF"
+            ],
+            "valid_tests": [
+                {
+                    "tc_id": 23,
+                    "comment": "No tweaks applied",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "expected": "08A866ABF049F70B7D842680EDB78C1C742D0368090B9F579CBE9D7019F53A8D"
+                },
+                {
+                    "tc_id": 24,
+                    "comment": "Single x-only tweak (used for BIP341 Taproot)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [0],
+                    "is_xonly": [true],
+                    "expected": "C8EFFDEE3AFD0E8CA02BFA16900E5AA2C00F3D64881A1983D77C6B5A64C0BC3C"
+                },
+                {
+                    "tc_id": 25,
+                    "comment": "Single plain tweak (used for BIP32 derivation)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [0],
+                    "is_xonly": [false],
+                    "expected": "C8EFFDEE3AFD0E8CA02BFA16900E5AA2C00F3D64881A1983D77C6B5A64C0BC3C"
+                },
+                {
+                    "tc_id": 26,
+                    "comment": "A plain tweak followed by an x-only tweak",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [0, 1],
+                    "is_xonly": [false, true],
+                    "expected": "15F4431495CDBB8930535A4EF31DA2C66D1DC3CDA13C182655A6961CD280F9F7"
+                },
+                {
+                    "tc_id": 27,
+                    "comment": "Four tweaks alternating x-only and plain",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [0, 1, 2, 3],
+                    "is_xonly": [true, false, true, false],
+                    "expected": "C6EF3457001788495D014A758DC8D540E2D8A6E478D7E2A3204D18B6D97BB632"
+                },
+                {
+                    "tc_id": 28,
+                    "comment": "Four tweaks: two plain followed by two x-only",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [0, 1, 2, 3],
+                    "is_xonly": [false, false, true, true],
+                    "expected": "468D28680CA66CBDBD6F5B0500D055E778806CC7CA72A2A5D08B8E8E1F5B35D1"
+                },
+                {
+                    "tc_id": 29,
+                    "comment": "Same tweaks as the previous case but with all signers participating, signed by a non-first member of the signer set",
+                    "my_id": 1,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 1,
+                    "secnonce_index": 1,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [0, 1, 2, 3],
+                    "is_xonly": [false, false, true, true],
+                    "expected": "0A2650D22510951BD711B57E0F4D3345B7000F40302043D4819EEE9D89CE431A"
+                }
+            ],
+            "error_tests": [
+                {
+                    "tc_id": 30,
+                    "comment": "Tweak exceeds the group order",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [4],
+                    "is_xonly": [false],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The tweak value is out of range."
+                    }
+                },
+                {
+                    "tc_id": 31,
+                    "comment": "Plain tweak drives the tweaked threshold public key to the point at infinity",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [5],
+                    "is_xonly": [false],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The result of tweaking cannot be infinity."
+                    }
+                },
+                {
+                    "tc_id": 32,
+                    "comment": "Number of tweaks does not match the number of tweak modes",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [0],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The tweaks and is_xonly arrays must have the same length."
+                    }
+                },
+                {
+                    "tc_id": 33,
+                    "comment": "Tweak is not a 32-byte array",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "030CC8DD7811033474FAD57D2DD03801584ED6A68CD1A73B3301C3DD1F685BBF7802DE9250BDBEF74C5EC1854A171EC8F5BD06CBDDCFB78384435AC62E5B359ACF2C",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [6],
+                    "is_xonly": [false],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The tweak must be a 32-byte array."
+                    }
+                }
+            ]
+        },
+        {
+            "tg_id": "3of5",
+            "t": 3,
+            "n": 5,
+            "thresh_pk": "03E1AEA00A7B8D0E0393664FEBBD31569A02CAF223D9AD83E90331DC18B1987358",
+            "pubshares": [
+                "02F333EDD2B6F532C2EF6C42E803B633A42289D0567A75C50EB1C8CF85EC480E8F",
+                "025322F63602ECCF146541B7C9EE4D1FCB84EC139471420472182AE968676A387F",
+                "0230639CEC0A83982E176D6905CE0620FDC57E151565A39D0E0821B8E753AE85B0",
+                "026E1A50E672FEDD3F3C378D6121E5702B050669DBC241D2C2299880152CD207BD",
+                "02DC06C4CA919DE70B4B8281901CCF9471AB91FBFBEE1A8C570D83911CAAF9E2FA"
+            ],
+            "pubnonces": [
+                "02EBD21E4F4EA2772BD4E427D98C9DC268894D18EC45E14063785B892D42921FF402FB73028B710ACBE49FC2D995757E077760CA7C1B2452791A3BDA086B91A1CEF3",
+                "02BCBEF1171F78857016B205C0C9DE61750CC21448C167AAFAFD9190962AEAFF79032798E533A65F94D1DFF901A2CB4F107D49FE6B0527E95D7AE24E4DBBB681F552",
+                "02A455D731ECDCAA59228CE82CA1B5CF45974F6E6D21EB57501BE22310F089BF69037E2647E73C022A913C87D8813D48E76D72313DF4697644C23DDE820DBEF76D4A",
+                "026730E278BDB65A8E771864103890A1F10BA5AB9B429E0843CCB45FD2D9052C6A03525D89B7C9615F846D36223D777C5D6BF134FD1981FCB2F6B94F7FA70CE668AB",
+                "034D048ED3554BE5D0F03308936060FAAA8A0889FD135E8176DC0843C4FB68A89903497442C3AC05C98A8FDDB40646A6203A6EA53E20846F8D0A863447011BE8EA71"
+            ],
+            "secshares": [
+                "77C9316A64770B17D500840E020A9478F793D37DB0E6A276CB4E6270187D6C90",
+                "74180420A784189B55F8C4667075E89C2064FF481B6ED2A23A7517AF71F6B7A8",
+                "BE6B9FB07586EBABD234EEE0A05E813DFFC14D73782085C8DFE77C1FADDA7172",
+                "56C40419CE7F844949B5037C91C45E5FDAF9E11917B31BAEFBD33133FBF258AD",
+                "3D21315CB26DE273BC79023A44A780006CBD971FA96F34904E0A95792C74AE9A"
+            ],
+            "secnonces": [
+                "8A1160479C4188DA237C53639EDEFC60C24E87F91AC8972D966000680A7D07328A5318B81726CB9B16B9321264611C7DF0C737BB64941F79D403D2D503FAB3AB",
+                "38214C927297FD9F61722C93A6568A7CFE37D8BFA7C73822337FEA77AD97A325CB33A2D2CB486A6F2EE597D7ED9D5552DD096452E3AC9DFA9787019BAB7652EB",
+                "E3490427C987333662C649E5801683B8BFCB7E5F0725908DBC968AA86AF1FA2C10E4690766A547CA58136EF3DC1045A8C3ECEA532A057F1A1AF1E42761E0ECD7",
+                "EE855A53463521DECAFA1132D121644CF0BBA4A860456F26540261023D9A49910E40FA146B6B9D4B8914D57D0B14A03BF5C753067CC144C69C14D924F037EF9E",
+                "CE5F5A722536E56561C5C1258A8E6A38480A7D00F79645460CCA3DE7F10E480308EF46C644D01F0FCB05950F384C655198101BDD83C604A8484FCCB49914CC39"
+            ],
+            "tweaks": [
+                "E8F791FF9225A2AF0102AFFF4A9A723D9612A682A25EBE79802B263CDFCD83BB",
+                "AE2EA797CC0FE72AC5B97B97F3C6957D7E4199A167A58EB08BCAFFDA70AC0455",
+                "F52ECBC565B3D8BEA2DFD5B75A4F457E54369809322E4120831626F290FA87E0",
+                "1969AD73CC177FA0B4FCED6DF1F7BF9907E665FDE9BA196A74FED0A3CF5AEF9D",
+                "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
+                "3680D87253A03CDEB0B3D228AAE37B2A356112D276C0AAF52D5F022B2EC7B117",
+                "E8F791FF9225A2AF0102AFFF4A9A723D9612A682A25EBE79802B263CDFCD83BBFF"
+            ],
+            "valid_tests": [
+                {
+                    "tc_id": 34,
+                    "comment": "No tweaks applied",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [],
+                    "is_xonly": [],
+                    "expected": "96630BAD23F362F641D8B88D89F006B2BB3EC7390D80743997ECFC9C96A13AD3"
+                },
+                {
+                    "tc_id": 35,
+                    "comment": "Single x-only tweak (used for BIP341 Taproot)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [0],
+                    "is_xonly": [true],
+                    "expected": "37A44A2791830833444BC5E6393B1F507A836B421E9D8269E2282A74B52D2F3E"
+                },
+                {
+                    "tc_id": 36,
+                    "comment": "Single plain tweak (used for BIP32 derivation)",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [0],
+                    "is_xonly": [false],
+                    "expected": "71BEE91B3D4A2DF955FC25E336F5BFA32607232580CF3E0E080749B30E5BBF4D"
+                },
+                {
+                    "tc_id": 37,
+                    "comment": "A plain tweak followed by an x-only tweak",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [0, 1],
+                    "is_xonly": [false, true],
+                    "expected": "D8D9171548E72DB21F403FA51902DB6FB73C64FB2E4512F8C84F4228EAEF9A7E"
+                },
+                {
+                    "tc_id": 38,
+                    "comment": "Four tweaks alternating x-only and plain",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [0, 1, 2, 3],
+                    "is_xonly": [true, false, true, false],
+                    "expected": "4E5B190157C2BDA2C0DA2630CC7D47F39F36D50BDE05B7FBCEE9B1317E721912"
+                },
+                {
+                    "tc_id": 39,
+                    "comment": "Four tweaks: two plain followed by two x-only",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "pubnonce_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [0, 1, 2, 3],
+                    "is_xonly": [false, false, true, true],
+                    "expected": "25113209B8EEB8E296DC6327AEF2DBC8F2F8562E41070472FEF2483345C34CB6"
+                },
+                {
+                    "tc_id": 40,
+                    "comment": "Same tweaks as the previous case but with all signers participating, signed by a non-first member of the signer set",
+                    "my_id": 1,
+                    "ids": [0, 1, 2, 3, 4],
+                    "pubshare_indices": [0, 1, 2, 3, 4],
+                    "pubnonce_indices": [0, 1, 2, 3, 4],
+                    "secshare_index": 1,
+                    "secnonce_index": 1,
+                    "aggnonce": "03536024F21D3C18E0F094D15E9DDA07740754905570A1B68CAFAC743A6C213745037C9EA6730CD21904C131FF4A6C62480A7BABAA75F0A4F63F1AFD8DEE9FDD699D",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [0, 1, 2, 3],
+                    "is_xonly": [false, false, true, true],
+                    "expected": "B87A1F629AA546EA9FB95FBC3B8E234AB93FEE695CFCB76C130693CFF8D45051"
+                }
+            ],
+            "error_tests": [
+                {
+                    "tc_id": 41,
+                    "comment": "Tweak exceeds the group order",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [4],
+                    "is_xonly": [false],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The tweak value is out of range."
+                    }
+                },
+                {
+                    "tc_id": 42,
+                    "comment": "Plain tweak drives the tweaked threshold public key to the point at infinity",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [5],
+                    "is_xonly": [false],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The result of tweaking cannot be infinity."
+                    }
+                },
+                {
+                    "tc_id": 43,
+                    "comment": "Number of tweaks does not match the number of tweak modes",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
+                    "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
+                    "tweak_indices": [0],
+                    "is_xonly": [],
+                    "error": {
+                        "type": "ValueError",
+                        "message": "The tweaks and is_xonly arrays must have the same length."
+                    }
+                },
+                {
+                    "tc_id": 44,
+                    "comment": "Tweak is not a 32-byte array",
+                    "my_id": 0,
+                    "ids": [0, 1, 2],
+                    "pubshare_indices": [0, 1, 2],
+                    "secshare_index": 0,
+                    "secnonce_index": 0,
+                    "aggnonce": "0391D52F656B3CA3E66AC5DAEF5B0D347F7E85B7DD7A9EBA10E9827AE23FB76E93031610E184E540470139F7626253F27E8871D6354941CC9FF94A07D83F61BB4CD5",
                     "msg": "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
                     "tweak_indices": [6],
                     "is_xonly": [false],


### PR DESCRIPTION
Address #53 

This branch makes the vector generator emit cases across several (t, n) threshold configurations instead of only 2-of-3. Most of the work lives in new shared machinery in `common.py`: a `Config` namedtuple, a `CONFIGS` list covering 2-of-3, 1-of-3, 3-of-3, and 3-of-5, and a `SharedGroupInputs` class that builds the full per-group bundle once per config.